### PR TITLE
fix: Suggested fix for: radmeth-adjust replaces significant p-values …

### DIFF
--- a/src/radmeth/radmeth-adjust.cpp
+++ b/src/radmeth/radmeth-adjust.cpp
@@ -136,7 +136,7 @@ stouffer_liptak(const vector<vector<double> > &corr_mat, vector<double> &pvals) 
 static bool
 is_number(const string& str) {
   for (const char &c : str)
-    if (c != '.' && !std::isdigit(c)) return false;
+    if (c != '.' && c != 'e' && c != '-' && !std::isdigit(c)) return false;
   return true;
 }
 


### PR DESCRIPTION
Fix for issue: 
* radmeth-adjust replaces significant p-values in scientific notation with '1' and thus hides best DMC #31