### PR TITLE
Counts bgzf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -113,7 +113,8 @@ libdnmtools_a_SOURCES += \
         src/common/TwoStateHMM.hpp \
         src/common/TwoStateHMM_PMD.hpp \
         src/common/bsutils.hpp \
-        src/common/numerical_utils.hpp
+        src/common/numerical_utils.hpp \
+        src/common/dnmt_error.hpp
 
 LDADD = libdnmtools.a  src/abismal/libabismal.a src/smithlab_cpp/libsmithlab_cpp.a
 

--- a/src/analysis/methcounts.cpp
+++ b/src/analysis/methcounts.cpp
@@ -492,7 +492,7 @@ process_reads(const bool VERBOSE,
 
 
 int
-main_methcounts(int argc, const char **argv) {
+main_counts(int argc, const char **argv) {
 
   try {
 

--- a/src/common/dnmt_error.hpp
+++ b/src/common/dnmt_error.hpp
@@ -1,0 +1,40 @@
+/* Copyright (C) 2023 Andrew D. Smith
+ *
+ * Authors: Andrew Smith
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#ifndef DNMT_ERROR_HPP
+#define DNMT_ERROR_HPP
+
+#include <stdexcept>
+#include <string>
+#include <cstring>
+
+struct dnmt_error: public std::exception {
+  int64_t err;        // error possibly from HTSlib
+  int the_errno;      // ERRNO at time of construction
+  std::string msg;         // the message
+  std::string the_what;    // to report
+  dnmt_error(const int64_t _err, const std::string &_msg) :
+    err{_err}, the_errno{errno}, msg{_msg} {
+    std::ostringstream oss;
+    oss << "[error: " << err << "][" << "ERRNO: " << the_errno << "]"
+        << "[" << strerror(the_errno) << "][" << msg << "]";
+    the_what = oss.str();
+  }
+  dnmt_error(const std::string &_msg) : dnmt_error(0, _msg) {}
+  const char*
+  what() const noexcept override {return the_what.c_str();}
+};
+
+#endif

--- a/src/dnmtools.cpp
+++ b/src/dnmtools.cpp
@@ -30,7 +30,7 @@ using std::endl;
 int abismal(int argc, const char **argv);
 int abismalidx(int argc, const char **argv);
 int simreads(int argc, const char **argv);
-int main_methcounts(int argc, const char **argv);
+int main_counts(int argc, const char **argv);
 int main_allelicmeth(int argc, const char **argv);
 int main_amrfinder(int argc, const char **argv);
 int main_amrtester(int argc, const char **argv);
@@ -114,7 +114,7 @@ print_help() {
   cout <<  sep+sep << "guessprotocol: guess whether protocol is ordinary, pbat or random\n";
   cout <<  sep+sep << "lc:            approximate line counts in a file\n";
   cout <<  sep+sep << "merge-bsrate:  merge the BS conversion rate from two sets of BS-seq reads mapped to a genome\n";
-  cout <<  sep+sep << "merge:         merge multiple methcounts files\n";
+  cout <<  sep+sep << "merge:         merge multiple counts files\n";
   cout <<  sep+sep << "selectsites:   sites inside a set of genomic intervals\n";
 
   cout <<  "\n";
@@ -128,7 +128,7 @@ main(int argc, const char **argv) {
   if (strcmp(argv[1], "abismal") == 0) ret = abismal(argc - 1, argv + 1);
   else if (strcmp(argv[1], "abismalidx") == 0) ret = abismalidx(argc - 1, argv + 1);
   else if (strcmp(argv[1], "simreads") == 0) ret = simreads(argc - 1, argv + 1);
-  else if (strcmp(argv[1], "counts") == 0) ret = main_methcounts(argc - 1, argv + 1);
+  else if (strcmp(argv[1], "counts") == 0) ret = main_counts(argc - 1, argv + 1);
   else if (strcmp(argv[1], "allelic") == 0) ret = main_allelicmeth(argc - 1, argv + 1);
   else if (strcmp(argv[1], "amrfinder") == 0) ret = main_amrfinder(argc - 1, argv + 1);
   else if (strcmp(argv[1], "amrtester") == 0) ret = main_amrtester(argc - 1, argv + 1);


### PR DESCRIPTION
Modifying code for the `counts` command to use bgzf output format and directly read HTSlib format BAM/SAM files so both kinds of IO can use threads. Additional optimizations for speed.