### PR TITLE
Radmeth gsl isolation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -97,7 +97,7 @@ TESTS = test_scripts/test_simreads.test \
         test_scripts/test_sym.test \
         test_scripts/test_hmr.test \
         test_scripts/test_roi.test \
-        test_scripts/test_selectsites.test 
+        test_scripts/test_selectsites.test
 
 TEST_EXTENSIONS = .test
 
@@ -144,6 +144,13 @@ libdnmtools_a_SOURCES += \
         src/common/numerical_utils.hpp \
         src/common/dnmt_error.hpp
 
+# ADS: additional radmeth sources to help isolate the parts using GSL for
+# optimization
+libdnmtools_a_SOURCES += \
+        src/radmeth/radmeth_optimize.hpp \
+        src/radmeth/radmeth_model.hpp
+
+
 LDADD = libdnmtools.a  src/abismal/libabismal.a src/smithlab_cpp/libsmithlab_cpp.a
 
 bin_PROGRAMS = dnmtools
@@ -180,6 +187,7 @@ dnmtools_SOURCES += src/amrfinder/amrtester.cpp
 
 dnmtools_SOURCES += src/radmeth/dmr.cpp
 dnmtools_SOURCES += src/radmeth/methdiff.cpp
+dnmtools_SOURCES += src/radmeth/radmeth_optimize.cpp
 dnmtools_SOURCES += src/radmeth/radmeth.cpp
 dnmtools_SOURCES += src/radmeth/radmeth-adjust.cpp
 dnmtools_SOURCES += src/radmeth/radmeth-merge.cpp

--- a/src/radmeth/methdiff.cpp
+++ b/src/radmeth/methdiff.cpp
@@ -2,7 +2,7 @@
  *           methylation in file A than in file B, where files A and B
  *           are specified on the command line.
  *
- * Copyright (C) 2011-2022 Andrew D Smith
+ * Copyright (C) 2011-2023 Andrew D Smith
  *
  * Author: Andrew D. Smith
  *
@@ -19,66 +19,70 @@
 
 #include <cmath>
 #include <fstream>
-#include <utility>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
-#include "smithlab_utils.hpp"
-#include "smithlab_os.hpp"
 #include "OptionParser.hpp"
+#include "smithlab_os.hpp"
+#include "smithlab_utils.hpp"
 #include "zlib_wrapper.hpp"
 
 #include "MSite.hpp"
 
-#include <gsl/gsl_sf_gamma.h>
-
-using std::string;
-using std::vector;
+using std::cerr;
 using std::cout;
 using std::endl;
-using std::cerr;
-using std::runtime_error;
 using std::min;
+using std::runtime_error;
+using std::string;
+using std::vector;
 
-using std::ostream_iterator;
 using std::ofstream;
+using std::ostream_iterator;
 
 static inline double
 log_sum_log(const double p, const double q) {
-  if (p == 0) {return q;}
-  else if (q == 0) {return p;}
+  if (p == 0) { return q; }
+  else if (q == 0) { return p; }
   const double larger = (p > q) ? p : q;
   const double smaller = (p > q) ? q : p;
   return larger + log(1.0 + exp(smaller - larger));
 }
 
-
-static double
-log_hyper_g_greater(size_t meth_a, size_t unmeth_a,
-                    size_t meth_b, size_t unmeth_b, size_t k) {
-  return  gsl_sf_lnchoose(meth_b + unmeth_b - 1, k) +
-    gsl_sf_lnchoose(meth_a + unmeth_a - 1, meth_a + meth_b - 1 - k) -
-    gsl_sf_lnchoose(meth_a + unmeth_a + meth_b + unmeth_b - 2,
-                    meth_a + meth_b - 1);
+static inline double
+lnchoose(const unsigned int n, unsigned int m) {
+  if (m == n || m == 0) return 0;
+  if (m * 2 > n) m = n - m;
+  using std::lgamma;
+  return lgamma(n + 1.0) - lgamma(m + 1.0) - lgamma((n - m) + 1.0);
 }
 
+static inline double
+log_hyper_g_greater(size_t meth_a, size_t unmeth_a, size_t meth_b,
+                    size_t unmeth_b, size_t k) {
+  return (
+    lnchoose(meth_b + unmeth_b - 1, k) +
+    lnchoose(meth_a + unmeth_a - 1, meth_a + meth_b - 1 - k) -
+    lnchoose(meth_a + unmeth_a + meth_b + unmeth_b - 2, meth_a + meth_b - 1));
+}
 
 static double
 test_greater_population(const size_t meth_a, const size_t unmeth_a,
                         const size_t meth_b, const size_t unmeth_b) {
   double p = 0;
   for (size_t k = (meth_b > unmeth_a) ? meth_b - unmeth_a : 0; k < meth_b; ++k)
-    p = log_sum_log(p, log_hyper_g_greater(meth_a, unmeth_a,
-                                           meth_b, unmeth_b, k));
+    p = log_sum_log(p,
+                    log_hyper_g_greater(meth_a, unmeth_a, meth_b, unmeth_b, k));
   return exp(p);
 }
 
-
-template <class T> T&
+template<class T> T &
 write_methdiff_site(T &out, const MSite &a, const MSite &b,
                     const double diffscore) {
   std::ostringstream oss;
+  // clang-format off
   oss << a.chrom << '\t'
       << a.pos << '\t'
       << a.strand << '\t'
@@ -88,23 +92,20 @@ write_methdiff_site(T &out, const MSite &a, const MSite &b,
       << a.n_unmeth() << '\t'
       << b.n_meth() << '\t'
       << b.n_unmeth() << '\n';
+  // clang-format on
   return out << oss.str();
 }
-
 
 static bool
 site_precedes(const size_t lhs_chrom_idx, const size_t lhs_pos,
               const size_t rhs_chrom_idx, const size_t rhs_pos) {
   return (lhs_chrom_idx < rhs_chrom_idx ||
-          (lhs_chrom_idx == rhs_chrom_idx &&
-           (lhs_pos < rhs_pos)));
+          (lhs_chrom_idx == rhs_chrom_idx && (lhs_pos < rhs_pos)));
 }
-
 
 static size_t
 get_chrom_id(std::unordered_map<string, size_t> &chrom_order,
-             std::unordered_set<string> &chroms_seen,
-             const MSite &s) {
+             std::unordered_set<string> &chroms_seen, const MSite &s) {
   if (chroms_seen.find(s.chrom) != end(chroms_seen))
     throw runtime_error("unsorted chromosomes found");
   chroms_seen.insert(s.chrom);
@@ -114,32 +115,31 @@ get_chrom_id(std::unordered_map<string, size_t> &chrom_order,
     chrom_order.insert(std::make_pair(s.chrom, idx));
     return idx;
   }
-  else return x->second;
+  else
+    return x->second;
 }
-
 
 static string
 bad_order(const std::unordered_map<string, size_t> &chrom_order,
-          const string prev_chrom, const size_t prev_pos,
-          const string chrom, const size_t pos) {
+          const string prev_chrom, const size_t prev_pos, const string chrom,
+          const size_t pos) {
   std::ostringstream oss;
   const size_t chrom_id = chrom_order.find(chrom)->second;
   const size_t prev_chrom_id = chrom_order.find(prev_chrom)->second;
+  // clang-format off
   oss << "bad order:\n"
-      << "chrom=" << chrom << " [id=" << chrom_id << "] pos="
-      << pos << "\n"
+      << "chrom=" << chrom << " [id=" << chrom_id << "] "
+      << "pos=" << pos << "\n"
       << "appears after\n"
-      << "chrom=" << prev_chrom << " [id=" << prev_chrom_id << "] pos="
-      << prev_pos << "\n";
+      << "chrom=" << prev_chrom << " [id=" << prev_chrom_id << "] "
+      << "pos=" << prev_pos << "\n";
+  // clang-format on
   return oss.str();
 }
 
-
-template <class T>
-static void
+template<class T> static void
 process_sites(const bool VERBOSE, igzfstream &in_a, igzfstream &in_b,
               const bool allow_uncovered, const double pseudocount, T &out) {
-
   // chromosome order in the files
   std::unordered_map<string, size_t> chrom_order;
   std::unordered_set<string> chroms_seen_a, chroms_seen_b;
@@ -151,17 +151,15 @@ process_sites(const bool VERBOSE, igzfstream &in_a, igzfstream &in_b,
   size_t prev_pos_a = 0, prev_pos_b = 0;
 
   while (in_a >> a) {
-
     if (prev_chrom_a.compare(a.chrom) != 0) {
       prev_chrom_id_a = chrom_id_a;
       chrom_id_a = get_chrom_id(chrom_order, chroms_seen_a, a);
       prev_chrom_a = a.chrom;
-      if (VERBOSE)
-        cerr << "processing " << a.chrom << endl;
+      if (VERBOSE) cerr << "processing " << a.chrom << endl;
     }
     if (site_precedes(chrom_id_a, a.pos, prev_chrom_id_a, prev_pos_a))
-      throw runtime_error(bad_order(chrom_order, prev_chrom_a, prev_pos_a,
-                                    a.chrom, a.pos));
+      throw runtime_error(
+        bad_order(chrom_order, prev_chrom_a, prev_pos_a, a.chrom, a.pos));
 
     bool advance_b = true;
     while (advance_b && in_b >> b) {
@@ -171,23 +169,21 @@ process_sites(const bool VERBOSE, igzfstream &in_a, igzfstream &in_b,
         prev_chrom_b = b.chrom;
       }
       if (site_precedes(chrom_id_b, b.pos, prev_chrom_id_b, prev_pos_b))
-        throw runtime_error(bad_order(chrom_order, prev_chrom_b, prev_pos_b,
-                                      b.chrom, b.pos));
+        throw runtime_error(
+          bad_order(chrom_order, prev_chrom_b, prev_pos_b, b.chrom, b.pos));
       advance_b = site_precedes(chrom_id_b, b.pos, chrom_id_a, a.pos);
       prev_pos_b = b.pos;
     }
 
     if (chrom_id_a == chrom_id_b && a.pos == b.pos) {
-
       if (allow_uncovered || min(a.n_reads, b.n_reads) > 0) {
-
         const size_t meth_a = a.n_meth() + pseudocount;
         const size_t unmeth_a = a.n_unmeth() + pseudocount;
         const size_t meth_b = b.n_meth() + pseudocount;
         const size_t unmeth_b = b.n_unmeth() + pseudocount;
 
-        const double diffscore = test_greater_population(meth_b, unmeth_b,
-                                                         meth_a, unmeth_a);
+        const double diffscore =
+          test_greater_population(meth_b, unmeth_b, meth_a, unmeth_a);
 
         write_methdiff_site(out, a, b, diffscore);
       }
@@ -196,12 +192,9 @@ process_sites(const bool VERBOSE, igzfstream &in_a, igzfstream &in_b,
   }
 }
 
-
 int
 main_methdiff(int argc, const char **argv) {
-
   try {
-
     string outfile;
     size_t pseudocount = 1;
 
@@ -214,11 +207,11 @@ main_methdiff(int argc, const char **argv) {
                            "compute probability that site "
                            "has higher methylation in file A than B",
                            "<counts-a> <counts-b>");
-    opt_parse.add_opt("pseudo", 'p', "pseudocount (default: 1)",
-                      false, pseudocount);
+    opt_parse.add_opt("pseudo", 'p', "pseudocount (default: 1)", false,
+                      pseudocount);
     opt_parse.add_opt("nonzero-only", 'A',
-                      "process only sites with coveage in both samples",
-                      false, allow_uncovered);
+                      "process only sites with coveage in both samples", false,
+                      allow_uncovered);
     opt_parse.add_opt("out", 'o', "output file", true, outfile);
     opt_parse.add_opt("verbose", 'v', "print more run info", false, VERBOSE);
     vector<string> leftover_args;
@@ -247,14 +240,12 @@ main_methdiff(int argc, const char **argv) {
     if (VERBOSE)
       cerr << "[opening methcounts file: " << cpgs_file_a << "]" << endl;
     igzfstream in_a(cpgs_file_a);
-    if (!in_a)
-      throw runtime_error("cannot open file: " + cpgs_file_a);
+    if (!in_a) throw runtime_error("cannot open file: " + cpgs_file_a);
 
     if (VERBOSE)
       cerr << "[opening methcounts file: " << cpgs_file_b << "]" << endl;
     igzfstream in_b(cpgs_file_b);
-    if (!in_b)
-      throw runtime_error("cannot open file: " + cpgs_file_b);
+    if (!in_b) throw runtime_error("cannot open file: " + cpgs_file_b);
 
     if (outfile.empty() || !has_gz_ext(outfile)) {
       std::ofstream of;

--- a/src/radmeth/radmeth.cpp
+++ b/src/radmeth/radmeth.cpp
@@ -1,6 +1,7 @@
-/* Copyright (C) 2013-2022 University of Southern California and
- *                    Egor Dolzhenko
- *                    Andrew D Smith
+/* Copyright (C) 2013-2023 University of Southern California and
+ *                         Egor Dolzhenko
+ *                         Andrew D Smith
+ *                         Guilherme Sena
  *
  * Authors: Andrew D. Smith and Egor Dolzhenko and Guilherme Sena
  *
@@ -15,79 +16,50 @@
  * General Public License for more details.
  */
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <vector>
-#include <string>
-#include <cmath>
-#include <algorithm>
+#include <gsl/gsl_cdf.h> // GSL header for chisqrd distribution
 
-// GSL headers
-#include <gsl/gsl_cdf.h>
-#include <gsl/gsl_multimin.h>
-#include <gsl/gsl_vector.h>
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 // smithlab headers
+#include "GenomicRegion.hpp"
 #include "OptionParser.hpp"
 #include "smithlab_os.hpp"
 #include "smithlab_utils.hpp"
-#include "GenomicRegion.hpp"
 
-using std::string;
-using std::vector;
-using std::istringstream;
+#include "radmeth_model.hpp"
+#include "radmeth_optimize.hpp"
+
+using std::begin;
 using std::cerr;
 using std::cout;
+using std::distance;
+using std::end;
 using std::endl;
-using std::istream;
-using std::ostream;
-using std::ifstream;
-using std::ofstream;
+using std::istringstream;
 using std::runtime_error;
 using std::sort;
-using std::min;
-using std::begin;
-using std::end;
+using std::string;
+using std::vector;
 
-/***************** REGRESSION *****************/
-struct Design {
-  vector<string> factor_names;
-  vector<string> sample_names;
-  vector<vector<double> > matrix;
-};
-
-struct SiteProportions {
-  string chrom;
-  size_t position;
-  string strand;
-  string context;
-  vector<size_t> total;
-  vector<size_t> meth;
-};
-
-struct Regression {
-  Design design;
-  SiteProportions props;
-  double max_loglik;
-};
-
-istream&
-operator>>(istream &is, Design &design) {
+static std::istream &
+operator>>(std::istream &is, Design &design) {
   string header_encoding;
   getline(is, header_encoding);
 
   istringstream header_is(header_encoding);
   string header_name;
-  while (header_is >> header_name)
-    design.factor_names.push_back(header_name);
+  while (header_is >> header_name) design.factor_names.push_back(header_name);
 
   string row;
   while (getline(is, row)) {
-
-    if (row.empty())
-      continue;
+    if (row.empty()) continue;
 
     istringstream row_is(row);
     string token;
@@ -99,13 +71,13 @@ operator>>(istream &is, Design &design) {
       if (token.length() == 1 && (token == "0" || token == "1"))
         matrix_row.push_back(token == "1");
       else
-        throw runtime_error("only binary factor levels are allowed:\n"
-                            + row);
+        throw runtime_error("only binary factor levels are allowed:\n" + row);
     }
 
-    if (matrix_row.size() != design.factor_names.size())
-      throw runtime_error("each row must have as many columns as "
-                          "factors:\n" + row);
+    if (matrix_row.size() != design.n_factors())
+      throw runtime_error(
+        "each row must have as many columns as factors:\n" +
+        row);
 
     design.matrix.push_back(vector<double>());
     swap(design.matrix.back(), matrix_row);
@@ -113,32 +85,28 @@ operator>>(istream &is, Design &design) {
   return is;
 }
 
-ostream&
-operator<<(ostream &os, const Design &design) {
-  for(size_t factor = 0; factor < design.factor_names.size(); ++factor) {
-    os << design.factor_names[factor];
-    if (factor + 1 != design.factor_names.size())
-      os << "\t";
+static std::ostream &
+operator<<(std::ostream &out, const Design &design) {
+  for (size_t factor = 0; factor < design.factor_names.size(); ++factor) {
+    out << design.factor_names[factor];
+    if (factor + 1 != design.factor_names.size()) out << "\t";
   }
-  os << endl;
+  out << endl;
 
-  for(size_t sample = 0; sample < design.sample_names.size(); ++sample) {
-    os << design.sample_names[sample] << "\t";
-    for(size_t factor = 0; factor < design.factor_names.size(); ++factor) {
-      os << design.matrix[sample][factor];
-      if (factor + 1 != design.factor_names.size())
-        os << "\t";
-    }
-    os << "\n";
+  for (size_t i = 0; i < design.n_samples(); ++i) {
+    out << design.sample_names[i];
+    for (size_t factor = 0; factor < design.factor_names.size(); ++factor)
+      out << "\t" << design.matrix[i][factor];
+    out << "\n";
   }
-  return os;
+  return out;
 }
 
-void
-remove_factor(Design &design, size_t factor) {
-  design.factor_names.erase(design.factor_names.begin() + factor);
-  for (size_t sample = 0; sample < design.sample_names.size(); ++sample)
-    design.matrix[sample].erase(design.matrix[sample].begin() + factor);
+static void
+remove_factor(Design &design, const size_t factor) {
+  design.factor_names.erase(begin(design.factor_names) + factor);
+  for (size_t i = 0; i < design.n_samples(); ++i)
+    design.matrix[i].erase(begin(design.matrix[i]) + factor);
 }
 
 // Parses a natural number from its string representation. Throws exception if
@@ -149,13 +117,13 @@ parse_natural_number(string encoding) {
   size_t number;
   iss >> number;
   if (!iss)
-    throw runtime_error("The token \"" +encoding + "\" "
-                        "does not encode a natural number");
+    throw runtime_error("The token \"" + encoding +
+                        "\" does not encode a natural number");
   return number;
 }
 
-istream&
-operator>>(istream &table_encoding, SiteProportions &props) {
+static std::istream &
+operator>>(std::istream &table_encoding, SiteProportions &props) {
   props.chrom.clear();
   props.position = 0;
   props.strand.clear();
@@ -168,8 +136,7 @@ operator>>(istream &table_encoding, SiteProportions &props) {
 
   // Skip lines contining only the newline character (e.g. the last line of the
   // proportion table).
-  if(row_encoding.empty())
-    return table_encoding;
+  if (row_encoding.empty()) return table_encoding;
 
   // Get the row name (which must be specified like this: "chr:position") and
   // parse it.
@@ -184,9 +151,10 @@ operator>>(istream &table_encoding, SiteProportions &props) {
     count(row_name_encoding.begin(), row_name_encoding.end(), ':');
 
   if (num_colon != 3)
-    throw runtime_error("Each row in the count table must start with "
-                        "a line chromosome:position:strand:context."
-                        "Got \"" + row_name_encoding + "\" instead." );
+    throw runtime_error(
+      "Each row in the count table must start with "
+      "a line chromosome:position:strand:context. Got \"" +
+      row_name_encoding + "\" instead.");
 
   // First parse the row identifier.
   istringstream name_stream(row_name_encoding);
@@ -216,258 +184,74 @@ operator>>(istream &table_encoding, SiteProportions &props) {
                         row_stream.str());
 
   if (props.total.size() != props.meth.size())
-    throw runtime_error("This row does not encode proportions"
-                        "correctly:\n" + row_encoding);
+    throw runtime_error(
+      "This row does not encode proportions"
+      "correctly:\n" +
+      row_encoding);
   return table_encoding;
 }
 
-static double
-pi(Regression *reg, size_t sample, const gsl_vector *parameters) {
-  double dot_prod = 0;
-  // ADS: this function doesn't have a very helpful name
-
-  for (size_t factor = 0; factor < reg->design.factor_names.size(); ++factor)
-    dot_prod +=
-      reg->design.matrix[sample][factor]*gsl_vector_get(parameters, factor);
-
-  double p = exp(dot_prod)/(1 + exp(dot_prod));
-
-  return p;
-}
-
-static double
-neg_loglik(const gsl_vector *parameters, void *object) {
-  Regression *reg = (Regression *)(object);
-  const size_t num_parameters = reg->design.factor_names.size() + 1;
-
-  double log_lik = 0;
-
-  //dispersion parameter phi is the last element of parameter vector
-  const double dispersion_param = gsl_vector_get(parameters,
-                                                 num_parameters - 1);
-  const double phi = exp(dispersion_param)/(1 + exp(dispersion_param));
-
-  for(size_t s = 0; s < reg->design.sample_names.size(); ++s) {
-    const double n_s = reg->props.total[s];
-    const double y_s = reg->props.meth[s];
-    const double p_s = pi(reg, s, parameters);
-
-    for(int k = 0; k < y_s; ++k) {
-      log_lik += log((1 - phi)*p_s + phi*k);
-    }
-
-    for(int k = 0; k < n_s - y_s; ++k) {
-      log_lik += log((1 - phi)*(1 - p_s) + phi*k);
-    }
-
-    for(int k = 0; k < n_s; ++k) {
-      log_lik -= log(1 + phi*(k - 1));
-    }
-  }
-
-  return (-1)*log_lik;
-}
-
-static void
-neg_gradient(const gsl_vector *parameters, void *object,
-             gsl_vector *output) {
-
-  Regression *reg = (Regression *)(object);
-  const size_t num_parameters = reg->design.factor_names.size() + 1;
-
-  const double dispersion_param = gsl_vector_get(parameters,
-                                                 num_parameters - 1);
-
-  const double phi = exp(dispersion_param)/(1 + exp(dispersion_param));
-
-  for(size_t f = 0; f < num_parameters; ++f) {
-
-    double deriv = 0;
-
-    for(size_t s = 0; s < reg->design.sample_names.size(); ++s) {
-      int n_s = reg->props.total[s];
-      int y_s = reg->props.meth[s];
-      double p_s = pi(reg, s, parameters);
-
-      double term = 0;
-
-      //a parameter linked to p
-      if(f < reg->design.factor_names.size()) {
-        double factor = (1 - phi)*p_s*(1 - p_s)*reg->design.matrix[s][f];
-        if (factor == 0) continue;
-
-        for(int k = 0; k < y_s; ++k)
-          term += 1/((1 - phi)*p_s + phi*k);
-
-        for(int k = 0; k < n_s - y_s; ++k)
-          term -= 1/((1 - phi)*(1 - p_s) + phi*k);
-
-        deriv += term*factor;
-      } else { // the parameter linked to phi
-        for(int k = 0; k < y_s; ++k)
-          term += (k - p_s)/((1 - phi)*p_s + phi*k);
-
-        for(int k = 0; k < n_s - y_s; ++k)
-          term += (k - (1 - p_s))/((1 - phi)*(1 - p_s) + phi*k);
-
-        for(int k = 0; k < n_s; ++k) {
-          term -= (k - 1)/(1 + phi*(k - 1));
-        }
-
-        deriv += term * phi * (1 - phi);
-      }
-    }
-
-    gsl_vector_set(output, f, deriv);
-  }
-
-  gsl_vector_scale(output, -1.0);
-}
-
-static void
-neg_loglik_and_grad(const gsl_vector *parameters,
-                    void *object,
-                    double *loglik_val,
-                    gsl_vector *d_loglik_val) {
-
-  *loglik_val = neg_loglik(parameters, object);
-  neg_gradient(parameters, object, d_loglik_val);
-}
-
-bool
-fit(Regression &r, vector<double> initial_parameters) {
-  const size_t num_parameters = r.design.factor_names.size() + 1;
-
-  if (initial_parameters.empty()) {
-    for(size_t ind = 0; ind < num_parameters - 1; ++ind)
-      initial_parameters.push_back(0.0);
-    initial_parameters.push_back(-2.5);
-  }
-
-  if (initial_parameters.size() != num_parameters)
-    throw runtime_error("Wrong number of initial parameters.");
-
-  int status = 0;
-
-  size_t iter = 0;
-
-  gsl_multimin_function_fdf loglik_bundle;
-
-  loglik_bundle.f = &neg_loglik;
-  loglik_bundle.df = &neg_gradient;
-  loglik_bundle.fdf = &neg_loglik_and_grad;
-  loglik_bundle.n = num_parameters;
-  loglik_bundle.params = (void *)&r;
-
-  gsl_vector *parameters = gsl_vector_alloc(num_parameters);
-
-  for (size_t parameter = 0; parameter < initial_parameters.size();
-       ++parameter) {
-    gsl_vector_set(parameters, parameter, initial_parameters[parameter]);
-  }
-
-  const gsl_multimin_fdfminimizer_type *T;
-
-  //can also try gsl_multimin_fdfminimizer_conjugate_pr;
-  T = gsl_multimin_fdfminimizer_conjugate_fr;
-
-  gsl_multimin_fdfminimizer *s;
-  s = gsl_multimin_fdfminimizer_alloc (T, num_parameters);
-
-  gsl_multimin_fdfminimizer_set (s, &loglik_bundle, parameters, 0.001, 1e-4);
-
-  do {
-    iter++;
-    status = gsl_multimin_fdfminimizer_iterate (s);
-
-    if (status)
-      break;
-
-    status = gsl_multimin_test_gradient (s->gradient, 1e-4);
-  }
-  while (status == GSL_CONTINUE && iter < 700);
-  //It it reasonable to reduce the number of iterations to 500?
-  // ADS: 700 vs. 500? what's the difference?
-
-  r.max_loglik = (-1)*neg_loglik(s->x, &r);
-
-  gsl_multimin_fdfminimizer_free(s);
-  gsl_vector_free(parameters);
-
-  return status == GSL_SUCCESS;
-}
-bool
-fit(Regression &r) {
-  return fit(r, vector<double>());
+static bool
+fit_regression_model(Regression &r) {
+  vector<double> initial_params;
+  return fit_regression_model(r, initial_params);
 }
 
 /***************** RADMETH ALGORITHM *****************/
-// Splits a string using white-space characters as delimeters.
-static vector<string>
-split(string input) {
-  istringstream iss(input);
+static bool
+consistent_sample_names(const Regression &reg, const string &header) {
+  istringstream iss(header);
+  auto nm_itr(begin(reg.design.sample_names));
+  const auto nm_end(end(reg.design.sample_names));
   string token;
-  vector<string> tokens;
-
-  while (iss >> token)
-    tokens.push_back(token);
-
-  return tokens;
+  while (iss >> token && nm_itr != nm_end)
+    if (token != *nm_itr++) return false;
+  return true;
 }
 
 // Given the maximum likelihood estimates of the full and reduced models, the
 // function outputs the p-value of the log-likelihood ratio. *Note* that it is
 // assumed that the reduced model has one fewer factor than the reduced model.
-double
+static double
 loglikratio_test(double null_loglik, double full_loglik) {
-
   // The log-likelihood ratio statistic.
-  const double log_lik_stat = -2*(null_loglik - full_loglik);
+  const double log_lik_stat = -2 * (null_loglik - full_loglik);
 
-  // It is assumed that null model has one fewer factor than the full model.
-  // Hence the number of degrees of freedom is 1.
+  // It is assumed that null model has one fewer factor than the full
+  // model. Hence the number of degrees of freedom is 1.
   const size_t degrees_of_freedom = 1;
 
   // Log-likelihood ratio statistic has a chi-sqare distribution.
-  double chisq_p = gsl_cdf_chisq_P(log_lik_stat, degrees_of_freedom);
-  const double pval = 1.0 - chisq_p;
+  const double chisq_p = gsl_cdf_chisq_P(log_lik_stat, degrees_of_freedom);
+  const double p_value = 1.0 - chisq_p;
 
-  return pval;
+  return p_value;
 }
 
-bool
-has_low_coverage(const Regression &reg, const size_t test_factor) {
+static bool
+has_low_coverage(const Regression &reg, const size_t test_fac) {
+  bool cvrd_in_test_fact_smpls = false;
+  for (size_t i = 0; i < reg.n_samples() && !cvrd_in_test_fact_smpls; ++i)
+    cvrd_in_test_fact_smpls =
+      (reg.design.matrix[i][test_fac] == 1 && reg.props.total[i] != 0);
 
-  bool is_covered_in_test_factor_samples = false;
-  bool is_covered_in_other_samples = false;
+  bool cvrd_in_other_smpls = false;
+  for (size_t i = 0; i < reg.n_samples() && !cvrd_in_other_smpls; ++i)
+    cvrd_in_other_smpls =
+      (reg.design.matrix[i][test_fac] != 1 && reg.props.total[i] != 0);
 
-  for (size_t sample = 0; sample < reg.design.sample_names.size(); ++sample) {
-    if (reg.design.matrix[sample][test_factor] == 1) {
-      if (reg.props.total[sample] != 0)
-        is_covered_in_test_factor_samples = true;
-    }
-    else {
-      if (reg.props.total[sample] != 0)
-        is_covered_in_other_samples = true;
-    }
-  }
-
-  return !is_covered_in_test_factor_samples || !is_covered_in_other_samples;
+  return !cvrd_in_test_fact_smpls || !cvrd_in_other_smpls;
 }
 
-bool
+static bool
 has_extreme_counts(const Regression &reg) {
-
   bool is_maximally_methylated = true;
+  for (size_t i = 0; i < reg.n_samples() && is_maximally_methylated; ++i)
+    is_maximally_methylated = (reg.props.total[i] == reg.props.meth[i]);
+
   bool is_unmethylated = true;
-
-  for (size_t sample = 0; sample < reg.design.sample_names.size(); ++sample) {
-    if (reg.props.total[sample] != reg.props.meth[sample])
-      is_maximally_methylated = false;
-
-    if (reg.props.meth[sample] != 0)
-      is_unmethylated = false;
-  }
+  for (size_t i = 0; i < reg.n_samples() && is_unmethylated; ++i)
+    is_unmethylated = (reg.props.meth[i] == 0.0);
 
   return is_maximally_methylated || is_unmethylated;
 }
@@ -478,9 +262,7 @@ has_extreme_counts(const Regression &reg) {
  */
 int
 main_radmeth(int argc, const char **argv) {
-
   try {
-
     static const string description =
       "calculate differential methylation scores";
 
@@ -493,14 +275,17 @@ main_radmeth(int argc, const char **argv) {
     OptionParser opt_parse(strip_path(argv[0]), description,
                            "<design-matrix> <data-matrix>");
     opt_parse.set_show_defaults();
-    opt_parse.add_opt("out", 'o', "output file (default: stdout)",
-                      false, outfile);
+    opt_parse.add_opt("out", 'o', "output file (default: stdout)", false,
+                      outfile);
     opt_parse.add_opt("verbose", 'v', "print more run info", false, VERBOSE);
-    opt_parse.add_opt("na-info", 'n',
-        "if a p-value is not calculated, print NAs in more detail: "
-        "low count (NA_LOW_COV) extreme values (NA_EXTREME_CNT) or"
-        " numerical errors in likelihood ratios (NA)", false, VERBOSE);
-    opt_parse.add_opt("factor", 'f', "a factor to test", true, test_factor_name);
+    opt_parse.add_opt(
+      "na-info", 'n',
+      "if a p-value is not calculated, print NAs in more detail: "
+      "low count (NA_LOW_COV) extreme values (NA_EXTREME_CNT) or "
+      "numerical errors in likelihood ratios (NA)",
+      false, more_na_info);
+    opt_parse.add_opt("factor", 'f', "a factor to test", true,
+                      test_factor_name);
 
     vector<string> leftover_args;
     opt_parse.parse(argc, argv, leftover_args);
@@ -525,63 +310,72 @@ main_radmeth(int argc, const char **argv) {
     const string table_filename(leftover_args.back());
     /****************** END COMMAND LINE OPTIONS *****************/
 
-    ifstream design_file(design_filename);
+    if (VERBOSE) cerr << "design table filename: " << design_filename << endl;
+    std::ifstream design_file(design_filename);
     if (!design_file)
       throw runtime_error("could not open file: " + design_filename);
-
-    ifstream table_file(table_filename);
-    if (!table_file)
-      throw runtime_error("could not open file: " + table_filename);
-
-    ofstream of;
-    if (!outfile.empty()) of.open(outfile);
-    ostream out(outfile.empty() ? cout.rdbuf() : of.rdbuf());
 
     // initialize full design matrix from file
     Regression full_regression;
     design_file >> full_regression.design;
 
+    if (VERBOSE) cerr << full_regression.design << endl;
+
     // Check that provided test factor name exists and find its index.
     // Identify test factors with their indexes to simplify naming
-    auto test_factor_it = find(begin(full_regression.design.factor_names),
-                               end(full_regression.design.factor_names),
-                               test_factor_name);
+    auto test_fact_it =
+      find(begin(full_regression.design.factor_names),
+           end(full_regression.design.factor_names), test_factor_name);
 
-    if (test_factor_it == end(full_regression.design.factor_names))
-      throw runtime_error("Error: " + test_factor_name +
-                          " is not a part of the design specification.");
+    if (test_fact_it == end(full_regression.design.factor_names))
+      throw runtime_error(test_factor_name +
+                          " factor not part of design specification");
 
-    const size_t test_factor = test_factor_it -
-      begin(full_regression.design.factor_names);
+    const size_t test_factor =
+      distance(begin(full_regression.design.factor_names), test_fact_it);
 
     Regression null_regression;
     null_regression.design = full_regression.design;
     remove_factor(null_regression.design, test_factor);
+    // ADS: done setup for the model
+
+
+    // ADS: open the data table file
+    std::ifstream table_file(table_filename);
+    if (!table_file)
+      throw runtime_error("could not open file: " + table_filename);
 
     // Make sure that the first line of the proportion table file contains
     // names of the samples. Throw an exception if the names or their order
     // in the proportion table does not match those in the full design matrix.
-    string sample_names_encoding;
-    getline(table_file, sample_names_encoding);
+    string sample_names_header;
+    getline(table_file, sample_names_header);
 
-    if (full_regression.design.sample_names != split(sample_names_encoding))
-      throw runtime_error(sample_names_encoding + " does not match factor "
-                          "names or their order in the design matrix. "
-                          "Please verify that the design matrix and the "
-                          "proportion table are correctly formatted.");
+    if (!consistent_sample_names(full_regression, sample_names_header))
+      // .design.sample_names != split_whitespace(sample_names_header))
+      throw runtime_error("header:\n" + sample_names_header + "\n" +
+                          "does not match factor names or their order in the\n"
+                          "design matrix. Check that the design matrix and\n"
+                          "the proportion table are correctly formatted.");
+
+    const size_t n_samples = full_regression.design.n_samples();
+
+    // ADS: now open the output file because each row is processed
+    // sequentially
+    std::ofstream of;
+    if (!outfile.empty()) of.open(outfile);
+    std::ostream out(outfile.empty() ? cout.rdbuf() : of.rdbuf());
 
     // Performing the log-likelihood ratio test on proportions from each row
     // of the proportion table.
     while (table_file >> full_regression.props) {
-
-      if (full_regression.design.sample_names.size() !=
-          full_regression.props.total.size())
+      if (full_regression.props.total.size() != n_samples)
         throw runtime_error("found row with wrong number of columns");
 
-      size_t coverage_factor = 0, coverage_rest = 0,
-        meth_factor = 0, meth_rest = 0;
+      size_t coverage_factor = 0, coverage_rest = 0, meth_factor = 0,
+             meth_rest = 0;
 
-      for(size_t s = 0; s < full_regression.design.sample_names.size(); ++s) {
+      for (size_t s = 0; s < n_samples; ++s) {
         if (full_regression.design.matrix[s][test_factor] != 0) {
           coverage_factor += full_regression.props.total[s];
           meth_factor += full_regression.props.meth[s];
@@ -597,9 +391,10 @@ main_radmeth(int argc, const char **argv) {
           << full_regression.props.strand << "\t"
           << full_regression.props.context << "\t";
 
-      // Do not perform the test if there's no coverage in either all case or
-      // all control samples. Also do not test if the site is completely
-      // methylated or completely unmethylated across all samples.
+      // Do not perform the test if there's no coverage in either all
+      // case or all control samples. Also do not test if the site is
+      // completely methylated or completely unmethylated across all
+      // samples.
       if (has_low_coverage(full_regression, test_factor)) {
         out << ((more_na_info) ? "NA_LOW_COV" : "NA");
       }
@@ -607,18 +402,20 @@ main_radmeth(int argc, const char **argv) {
         out << ((more_na_info) ? "NA_EXTREME_CNT" : "NA");
       }
       else {
-        fit(full_regression);
+        fit_regression_model(full_regression);
         null_regression.props = full_regression.props;
-        fit(null_regression);
-        const double pval = loglikratio_test(null_regression.max_loglik,
-                                             full_regression.max_loglik);
+        fit_regression_model(null_regression);
+        const double p_value = loglikratio_test(null_regression.max_loglik,
+                                                full_regression.max_loglik);
 
         // If error occured in fitting (p-val = nan or -nan).
-        if (pval != pval) out << "NA";
-        else out << pval;
+        if (p_value != p_value)
+          out << "NA";
+        else
+          out << p_value;
       }
-      out << "\t" << coverage_factor << "\t" << meth_factor
-          << "\t" << coverage_rest << "\t" << meth_rest << endl;
+      out << "\t" << coverage_factor << "\t" << meth_factor << "\t"
+          << coverage_rest << "\t" << meth_rest << endl;
     }
   }
   catch (const std::exception &e) {

--- a/src/radmeth/radmeth_model.hpp
+++ b/src/radmeth/radmeth_model.hpp
@@ -1,0 +1,50 @@
+/* Copyright (C) 2013-2023 University of Southern California and
+ *                         Egor Dolzhenko
+ *                         Andrew D Smith
+ *                         Guilherme Sena
+ *
+ * Authors: Andrew D. Smith and Egor Dolzhenko and Guilherme Sena
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#ifndef RADMETH_MODEL_HPP
+#define RADMETH_MODEL_HPP
+
+#include <string>
+#include <vector>
+
+struct Design {
+  std::vector<std::string> factor_names;
+  std::vector<std::string> sample_names;
+  std::vector<std::vector<double> > matrix;
+  size_t n_factors() const {return factor_names.size();}
+  size_t n_samples() const {return sample_names.size();}
+};
+
+struct SiteProportions {
+  std::string chrom;
+  size_t position;
+  std::string strand;
+  std::string context;
+  std::vector<size_t> total;
+  std::vector<size_t> meth;
+};
+
+struct Regression {
+  Design design;
+  SiteProportions props;
+  double max_loglik;
+  size_t n_factors() const {return design.n_factors();}
+  size_t n_samples() const {return design.n_samples();}
+};
+
+#endif

--- a/src/radmeth/radmeth_optimize.cpp
+++ b/src/radmeth/radmeth_optimize.cpp
@@ -1,0 +1,199 @@
+/* Copyright (C) 2013-2023 University of Southern California and
+ *                         Egor Dolzhenko
+ *                         Andrew D Smith
+ *                         Guilherme Sena
+ *
+ * Authors: Andrew D. Smith and Egor Dolzhenko and Guilherme Sena
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#include "radmeth_model.hpp"
+
+#include <gsl/gsl_multimin.h>
+#include <gsl/gsl_vector.h>
+
+#include <stdexcept>
+#include <vector>
+
+using std::vector;
+using std::runtime_error;
+
+static double
+pi(Regression *reg, size_t sample, const gsl_vector *params) {
+  // ADS: this function doesn't have a very helpful name
+  double dot_prod = 0;
+  for (size_t fact = 0; fact < reg->design.n_factors(); ++fact)
+    dot_prod += reg->design.matrix[sample][fact]*gsl_vector_get(params, fact);
+
+  double p = exp(dot_prod)/(1 + exp(dot_prod));
+
+  return p;
+}
+
+
+static double
+neg_loglik(const gsl_vector *params, void *object) {
+  Regression *reg = (Regression *)(object);
+  const size_t n_params = reg->design.factor_names.size() + 1;
+
+  double log_lik = 0;
+
+  // ADS: the dispersion parameter phi is the last element of
+  // parameter vector
+  const double disp_param = gsl_vector_get(params, n_params - 1);
+  const double phi = exp(disp_param)/(1.0 + exp(disp_param));
+
+  for(size_t s = 0; s < reg->design.n_samples(); ++s) {
+    const double n_s = reg->props.total[s];
+    const double y_s = reg->props.meth[s];
+    const double p_s = pi(reg, s, params);
+
+    for (int k = 0; k < y_s; ++k)
+      log_lik += log((1 - phi)*p_s + phi*k);
+
+    for (int k = 0; k < n_s - y_s; ++k)
+      log_lik += log((1 - phi)*(1 - p_s) + phi*k);
+
+    for (int k = 0; k < n_s; ++k)
+      log_lik -= log(1.0 + phi*(k - 1));
+  }
+
+  return -log_lik;
+}
+
+
+static void
+neg_gradient(const gsl_vector *params, void *object,
+             gsl_vector *output) {
+
+  Regression *reg = (Regression *)(object);
+  const size_t n_params = reg->design.n_factors() + 1;
+
+  const double disp_param = gsl_vector_get(params, n_params - 1);
+
+  const double phi = exp(disp_param)/(1 + exp(disp_param));
+
+  for(size_t f = 0; f < n_params; ++f) {
+
+    double deriv = 0;
+
+    for(size_t s = 0; s < reg->design.n_samples(); ++s) {
+      int n_s = reg->props.total[s];
+      int y_s = reg->props.meth[s];
+      double p_s = pi(reg, s, params);
+
+      double term = 0;
+
+      //a parameter linked to p
+      if(f < reg->design.factor_names.size()) {
+        double factor = (1 - phi)*p_s*(1 - p_s)*reg->design.matrix[s][f];
+        if (factor == 0) continue;
+
+        for(int k = 0; k < y_s; ++k)
+          term += 1/((1 - phi)*p_s + phi*k);
+
+        for(int k = 0; k < n_s - y_s; ++k)
+          term -= 1/((1 - phi)*(1 - p_s) + phi*k);
+
+        deriv += term*factor;
+      } else { // the parameter linked to phi
+        for(int k = 0; k < y_s; ++k)
+          term += (k - p_s)/((1 - phi)*p_s + phi*k);
+
+        for(int k = 0; k < n_s - y_s; ++k)
+          term += (k - (1 - p_s))/((1 - phi)*(1 - p_s) + phi*k);
+
+        for(int k = 0; k < n_s; ++k) {
+          term -= (k - 1)/(1 + phi*(k - 1));
+        }
+
+        deriv += term * phi * (1 - phi);
+      }
+    }
+
+    gsl_vector_set(output, f, deriv);
+  }
+
+  gsl_vector_scale(output, -1.0);
+}
+
+static void
+neg_loglik_and_grad(const gsl_vector *params,
+                    void *object,
+                    double *loglik_val,
+                    gsl_vector *d_loglik_val) {
+
+  *loglik_val = neg_loglik(params, object);
+  neg_gradient(params, object, d_loglik_val);
+}
+
+
+bool
+fit_regression_model(Regression &r, vector<double> &initial_params) {
+
+  // one more than the number of factors
+  const size_t n_params = r.n_factors() + 1;
+  if (initial_params.empty()) {
+    initial_params.resize(n_params, 0.0);
+    initial_params.back() = -2.5;
+  }
+
+  if (initial_params.size() != n_params)
+    throw runtime_error("Wrong number of initial parameters.");
+
+  int status = 0;
+
+  size_t iter = 0;
+
+  {
+    gsl_multimin_function_fdf loglik_bundle;
+    loglik_bundle.f = &neg_loglik;
+    loglik_bundle.df = &neg_gradient;
+    loglik_bundle.fdf = &neg_loglik_and_grad;
+    loglik_bundle.n = n_params;
+    loglik_bundle.params = (void *)&r;
+
+    gsl_vector *params = gsl_vector_alloc(n_params);
+
+    for (size_t param = 0; param < initial_params.size(); ++param)
+      gsl_vector_set(params, param, initial_params[param]);
+
+    //can also try gsl_multimin_fdfminimizer_conjugate_pr;
+    const gsl_multimin_fdfminimizer_type *T = gsl_multimin_fdfminimizer_conjugate_fr;
+
+    gsl_multimin_fdfminimizer *s = gsl_multimin_fdfminimizer_alloc (T, n_params);
+
+    // ADS: 0.001 is the step size and 1e-4 is the tolerance
+    // get the minimizer
+    gsl_multimin_fdfminimizer_set(s, &loglik_bundle, params, 0.001, 1e-4);
+
+    do {
+      iter++;
+      // do one iteration and get the status
+      status = gsl_multimin_fdfminimizer_iterate(s);
+      if (status)
+        break;
+      // check the status based on gradient
+      status = gsl_multimin_test_gradient (s->gradient, 1e-4);
+    }
+    while (status == GSL_CONTINUE && iter < 700);
+    // It it reasonable to reduce the number of iterations to 500?
+    // ADS: 700 vs. 500? what's the difference?
+
+    r.max_loglik = (-1)*neg_loglik(s->x, &r);
+
+    gsl_multimin_fdfminimizer_free(s);
+    gsl_vector_free(params);
+  }
+
+  return status == GSL_SUCCESS;
+}

--- a/src/radmeth/radmeth_optimize.hpp
+++ b/src/radmeth/radmeth_optimize.hpp
@@ -1,0 +1,28 @@
+/* Copyright (C) 2013-2023 University of Southern California and
+ *                         Egor Dolzhenko
+ *                         Andrew D Smith
+ *                         Guilherme Sena
+ *
+ * Authors: Andrew D. Smith and Egor Dolzhenko and Guilherme Sena
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#ifndef RADMETH_OPTIMIZE_HPP
+#define RADMETH_OPTIMIZE_HPP
+
+struct Regression;
+
+bool
+fit_regression_model(Regression &r, std::vector<double> &initial_params);
+
+
+#endif


### PR DESCRIPTION
Moved the GSL code for regression, which uses general miltidimensional minization, into separate source files. The purpose of this is to eventually eliminate the use of GSL. Also, the `gsl_sflnchoose` in `methdiff.cpp` was replaced with a fully written function that uses the standard lgamma.