### PR TITLE
diff comand: sites sorted and syncd

### DIFF
--- a/docs/content/diff.md
+++ b/docs/content/diff.md
@@ -38,6 +38,11 @@ in `input-a.meth`, number of unmethylated reads in `input-a.meth`,
 number of methylated reads in `input-b.meth`, and number of
 unmethylated reads in `input-b.meth`, respectively.
 
+The two input files must be have all sites within a chromosomes
+consecutive, have the same chromosome order, and have sites sorted in
+increasing order within each chromosome. The order of chromosomes does
+not matter (e.g., chr10 may precede chr2, or chr2 may precede chr10).
+
 **Warning** the order of the samples/methylomes given as input, the
 "a" and "b", matters. It is probably a good idea to include this order
 in the output file name, for example as `output_a_lt_b.diff`.

--- a/src/radmeth/methdiff.cpp
+++ b/src/radmeth/methdiff.cpp
@@ -281,12 +281,12 @@ main_methdiff(int argc, const char **argv) {
     /****************** END COMMAND LINE OPTIONS *****************/
 
     if (VERBOSE)
-      cerr << "[opening methcounts file: " << cpgs_file_a << "]" << endl;
+      cerr << "[opening counts file: " << cpgs_file_a << "]" << endl;
     bgzf_file in_a(cpgs_file_a, "r");
     if (!in_a) throw runtime_error("cannot open file: " + cpgs_file_a);
 
     if (VERBOSE)
-      cerr << "[opening methcounts file: " << cpgs_file_b << "]" << endl;
+      cerr << "[opening counts file: " << cpgs_file_b << "]" << endl;
     bgzf_file in_b(cpgs_file_b, "r");
     if (!in_b) throw runtime_error("cannot open file: " + cpgs_file_b);
 


### PR DESCRIPTION
Updating the `diff` command. The sites must be sorted, and this is checked in both files, but their chromosome order need only be consistent with each other. Sites will now be synchronized so that sites differing between the two inputs are ignored, but as long as sites are sorted in a consistent way between the two inputs, the sites in common will be processed.