### PR TITLE
Fixing problem because of macOS

### DIFF
--- a/src/analysis/bsrate.cpp
+++ b/src/analysis/bsrate.cpp
@@ -147,21 +147,23 @@ struct bsrate_summary {
   void set_values() {
     bisulfite_conversion_rate_positive =
       static_cast<double>(converted_count_positive) /
-      max(total_count_positive, 1ul);
+      max(total_count_positive, static_cast<uint64_t>(1));
 
     bisulfite_conversion_rate_negative =
       static_cast<double>(converted_count_negative) /
-      max(total_count_negative, 1ul);
+      max(total_count_negative, static_cast<uint64_t>(1));
 
     converted_count = converted_count_positive + converted_count_negative;
     total_count = total_count_positive + total_count_negative;
 
     bisulfite_conversion_rate =
-      static_cast<double>(converted_count) / max(total_count, 1ul);
+      static_cast<double>(converted_count) /
+      max(total_count, static_cast<uint64_t>(1));
 
     valid_count = total_count + error_count;
 
-    error_rate = static_cast<double>(error_count) / max(valid_count, 1ul);
+    error_rate = static_cast<double>(error_count) /
+      max(valid_count, static_cast<uint64_t>(1));
   }
 
   string tostring_as_row() const {

--- a/src/analysis/hmr.cpp
+++ b/src/analysis/hmr.cpp
@@ -56,8 +56,9 @@ struct hmr_summary {
     hmr_total_size = accumulate(cbegin(hmrs), cend(hmrs), 0,
                                 [](const uint64_t t, const GenomicRegion &p) {
                                   return t + p.get_width(); });
-    hmr_mean_size = 
-      static_cast<double>(hmr_total_size)/std::max(1ul, hmr_count);
+    hmr_mean_size =
+      static_cast<double>(hmr_total_size)/
+      std::max(hmr_count, static_cast<uint64_t>(1));
   }
   // hmr_count is the number of identified HMRs.
   uint64_t hmr_count{};
@@ -452,7 +453,7 @@ main_hmr(int argc, const char **argv) {
     opt_parse.add_opt("params-out", 'p', "write HMM parameters to this "
                       "file (default: none)", false, params_out_file);
     opt_parse.add_opt("seed", 's', "specify random seed", false, rng_seed);
-    opt_parse.add_opt("summary", 'S', "write summary output here", false, 
+    opt_parse.add_opt("summary", 'S', "write summary output here", false,
                       summary_file);
     opt_parse.set_show_defaults();
     vector<string> leftover_args;

--- a/src/analysis/pmd.cpp
+++ b/src/analysis/pmd.cpp
@@ -64,7 +64,7 @@ struct pmd_summary {
                                 [](const uint64_t t, const GenomicRegion &p) {
                                   return t + p.get_width(); });
     pmd_mean_size =
-      static_cast<double>(pmd_total_size)/std::max(1ul, pmd_count);
+      static_cast<double>(pmd_total_size)/std::max(pmd_count, static_cast<uint64_t>(1));
   }
   // pmd_count is the number of identified PMDs.
   uint64_t pmd_count{};

--- a/src/common/LevelsCounter.cpp
+++ b/src/common/LevelsCounter.cpp
@@ -31,7 +31,7 @@ LevelsCounter::update(const MSite &s) {
   }
   if (s.n_reads > 0) {
     ++sites_covered;
-    max_depth = std::max(max_depth, s.n_reads);
+    max_depth = std::max(max_depth, static_cast<uint64_t>(s.n_reads));
     total_c += s.n_meth();
     total_t += s.n_reads - s.n_meth();
     total_meth += s.meth;

--- a/src/common/LevelsCounter.hpp
+++ b/src/common/LevelsCounter.hpp
@@ -81,21 +81,24 @@ struct LevelsCounter {
   // is the ratio of total_c divided by coverage. This value is always
   // between 0 and 1.
   double mean_meth_weighted() const {
-    return static_cast<double>(total_c)/std::max(coverage(), 1ul);
+    return static_cast<double>(total_c)/
+      std::max(coverage(), static_cast<uint64_t>(1));
   }
 
   // fractional_meth is the fraction of "called" sites that are called
   // methylated. It is the ratio of called_meth divided by
   // total_called. This value is always between 0 and 1.
   double fractional_meth() const {
-    return static_cast<double>(called_meth)/std::max(total_called(), 1ul);
+    return static_cast<double>(called_meth)/
+      std::max(total_called(), static_cast<uint64_t>(1));
   }
 
   // mean_meth is the unweighted mean methylation level. This is the
   // ratio of total_meth divided by sites_covered. This value is
   // always between 0 and 1.
   double mean_meth() const {
-    return static_cast<double>(total_meth)/std::max(sites_covered, 1ul);
+    return static_cast<double>(total_meth)/
+      std::max(sites_covered, static_cast<uint64_t>(1));
   }
 
   LevelsCounter(const std::string &c) : context{c} {}


### PR DESCRIPTION
Fixing problem with macOS not allowing comparison between unsigned long and uint64_t by static casting ul to uint64_t.