### PR TITLE
silencing compiler warnings

### DIFF
--- a/src/amrfinder/amrfinder.cpp
+++ b/src/amrfinder/amrfinder.cpp
@@ -186,7 +186,7 @@ convert_coordinates(const string &genome_file, vector<GenomicRegion> &amrs) {
 
   unordered_map<string, string> chrom_lookup;
   for (auto i = 0u; i < n_chroms; ++i)
-    chrom_lookup.emplace(move(c_name[i]), move(c_seq[i]));
+    chrom_lookup.emplace(std::move(c_name[i]), std::move(c_seq[i]));
 
   vector<pair<uint32_t, uint32_t>> chrom_parts = get_chrom_partition(amrs);
   std::atomic_uint32_t conv_failure = 0;
@@ -300,7 +300,8 @@ process_chrom(const bool verbose, const uint32_t n_threads,
   const auto n_blocks = n_threads*blocks_per_thread;
 
   const uint64_t lim = n_cpgs - window_size + 1;
-  const auto blocks = get_block_bounds(0ul, lim, lim/n_blocks);
+  const auto blocks = get_block_bounds(static_cast<decltype(lim)>(0),
+                                       lim, lim/n_blocks);
 
   atomic_ulong windows_tested = 0;
 
@@ -324,7 +325,7 @@ process_chrom(const bool verbose, const uint32_t n_threads,
     }
 #pragma omp critical
     {
-      all_amrs.push_back(move(curr_amrs));
+      all_amrs.push_back(std::move(curr_amrs));
     }
     windows_tested += windows_tested_block;
   }
@@ -335,7 +336,7 @@ process_chrom(const bool verbose, const uint32_t n_threads,
 
   amrs.reserve(total_amrs);
   for (auto &v : all_amrs)
-    for (auto &a : v) amrs.push_back(move(a));
+    for (auto &a : v) amrs.push_back(std::move(a));
 
   return windows_tested;
 }

--- a/src/amrfinder/amrfinder.cpp
+++ b/src/amrfinder/amrfinder.cpp
@@ -300,7 +300,7 @@ process_chrom(const bool verbose, const uint32_t n_threads,
   const auto n_blocks = n_threads*blocks_per_thread;
 
   const uint64_t lim = n_cpgs - window_size + 1;
-  const auto blocks = get_block_bounds(static_cast<decltype(lim)>(0),
+  const auto blocks = get_block_bounds(static_cast<uint64_t>(0),
                                        lim, lim/n_blocks);
 
   atomic_ulong windows_tested = 0;

--- a/src/analysis/bsrate.cpp
+++ b/src/analysis/bsrate.cpp
@@ -536,7 +536,8 @@ main_bsrate(int argc, const char **argv) {
 
         auto chrom_itr = chrom_lookup.find(the_tid);
         if (chrom_itr == end(chrom_lookup))
-          throw runtime_error("could not find chrom: " + the_tid);
+          throw runtime_error("could not find chrom: " +
+                              std::to_string(the_tid));
 
         chrom_idx = chrom_itr->second;
 

--- a/src/analysis/hmr-rep.cpp
+++ b/src/analysis/hmr-rep.cpp
@@ -104,8 +104,7 @@ get_domain_scores_rep(const vector<bool> &state_ids,
 
 
 static void
-build_domains(const bool VERBOSE,
-              const vector<MSite> &cpgs,
+build_domains(const vector<MSite> &cpgs,
               const vector<double> &post_scores,
               const vector<size_t> &reset_points,
               const vector<bool> &state_ids,
@@ -506,7 +505,7 @@ main_hmr_rep(int argc, const char **argv) {
       fdr_cutoff = get_stepup_cutoff(p_values, 0.01);
 
     vector<GenomicRegion> domains;
-    build_domains(VERBOSE, cpgs, posteriors, reset_points, state_ids, domains);
+    build_domains(cpgs, posteriors, reset_points, state_ids, domains);
 
     std::ofstream of;
     if (!outfile.empty()) of.open(outfile);

--- a/src/analysis/hmr.cpp
+++ b/src/analysis/hmr.cpp
@@ -139,8 +139,7 @@ get_domain_scores(const vector<bool> &state_ids,
 
 
 static void
-build_domains(const bool VERBOSE,
-              const vector<MSite> &cpgs,
+build_domains(const vector<MSite> &cpgs,
               const vector<double> &post_scores,
               const vector<size_t> &reset_points,
               const vector<bool> &state_ids,
@@ -557,7 +556,7 @@ main_hmr(int argc, const char **argv) {
                         p_fb, p_bf, domain_score_cutoff);
 
     vector<GenomicRegion> domains;
-    build_domains(VERBOSE, cpgs, posteriors, reset_points, state_ids, domains);
+    build_domains(cpgs, posteriors, reset_points, state_ids, domains);
 
     std::ofstream of;
     if (!outfile.empty()) of.open(outfile.c_str());

--- a/src/analysis/hypermr.cpp
+++ b/src/analysis/hypermr.cpp
@@ -106,9 +106,13 @@ separate_regions(const size_t desert_size, vector<MSite> &cpgs, vector<T> &meth,
   reset_points.push_back(cpgs.size());
 }
 
+
+// ADS (!!!) this function seems to not be working at all right now
 static void
-read_params_file(const string &params_file, betabin &hypo_emission,
-                 betabin &HYPER_emission, betabin &HYPO_emission,
+read_params_file(const string &params_file,
+                 // betabin &hypo_emission,
+                 // betabin &HYPER_emission,
+                 // betabin &HYPO_emission,
                  vector<vector<double>> &trans) {
   std::ifstream in(params_file);
   if (!in) throw runtime_error("failed to read param file: " + params_file);
@@ -142,7 +146,7 @@ write_params_file(const string &params_file, const betabin &hypo_emission,
 }
 
 static void
-build_domains(const bool VERBOSE, const vector<MSite> &cpgs,
+build_domains(const vector<MSite> &cpgs,
               const vector<pair<double, double>> &meth,
               const vector<size_t> &reset_points,
               const vector<STATE_LABELS> &classes,
@@ -190,7 +194,7 @@ build_domains(const bool VERBOSE, const vector<MSite> &cpgs,
 }
 
 static void
-filter_domains(const bool VERBOSE, const double min_cumulative_meth,
+filter_domains(const double min_cumulative_meth,
                vector<GenomicRegion> &domains) {
   size_t j = 0;
   for (size_t i = 0; i < domains.size(); ++i)
@@ -317,8 +321,11 @@ main_hypermr(int argc, const char **argv) {
     betabin hypo_emission, HYPER_emission, HYPO_emission;
 
     if (!params_in_file.empty())
-      read_params_file(params_in_file, hypo_emission, HYPER_emission,
-                       HYPO_emission, trans);
+      read_params_file(params_in_file,
+                       // hypo_emission,
+                       // HYPER_emission,
+                       // HYPO_emission,
+                       trans);
     else {
       const double n_reads = mean_cov;
       const double fg_alpha = 0.33 * n_reads;
@@ -349,9 +356,8 @@ main_hypermr(int argc, const char **argv) {
 
     // identify the domains of hypermethylation
     vector<GenomicRegion> domains;
-    build_domains(VERBOSE, cpgs, hmm.observations, reset_points, classes,
-                  domains);
-    filter_domains(VERBOSE, min_cumulative_meth, domains);
+    build_domains(cpgs, hmm.observations, reset_points, classes, domains);
+    filter_domains(min_cumulative_meth, domains);
 
     // write the results
     ofstream of;

--- a/src/analysis/multimethstat.cpp
+++ b/src/analysis/multimethstat.cpp
@@ -162,7 +162,7 @@ all_is_finite(const vector<double> &scores) {
 
 static void
 process_with_cpgs_loaded(const bool VERBOSE,
-                         const bool sort_data_if_needed,
+                         // const bool sort_data_if_needed,
                          const bool PRINT_NUMERIC_ONLY,
                          const bool report_more_information,
                          const char level_code,
@@ -625,7 +625,7 @@ main_multimethstat(int argc, const char **argv) {
     std::ostream out(outfile.empty() ? cout.rdbuf() : of.rdbuf());
 
     if (load_entire_file)
-      process_with_cpgs_loaded(VERBOSE, sort_data_if_needed,
+      process_with_cpgs_loaded(VERBOSE, // sort_data_if_needed,
                                PRINT_NUMERIC_ONLY,
                                report_more_information,
                                level_code[0],

--- a/src/common/EpireadStats.cpp
+++ b/src/common/EpireadStats.cpp
@@ -292,8 +292,8 @@ compute_model_likelihoods(double &single_score, double &pair_score,
   vector<double> a1(n_cpgs, low_prob), a2(n_cpgs, high_prob), indicators;
   resolve_epialleles(max_itr, reads, mixing, indicators, a1, a2);
 
-  constexpr double log_mixing1 = log(mixing);
-  constexpr double log_mixing2 = log(1.0 - mixing);
+  const double log_mixing1 = log(mixing);
+  const double log_mixing2 = log(1.0 - mixing);
 
   pair_score = transform_reduce(
     cbegin(reads), cend(reads), 0.0, std::plus<>(),

--- a/src/common/MSite.cpp
+++ b/src/common/MSite.cpp
@@ -82,8 +82,13 @@ MSite::MSite(const string &line) {
   failed = failed || (field_e == c_end);
 
   {
+#ifdef __APPLE__
+    const int ret = std::sscanf(field_s, "%lf", &meth);
+    failed = failed || (ret < 1);
+#else
     const auto [ptr, ec] = from_chars(field_s, field_e, meth);
     failed = failed || (ptr == field_s);
+#endif
   }
 
   field_s = find_if(field_e + 1, c_end, not_sep);

--- a/src/common/ThreeStateHMM.cpp
+++ b/src/common/ThreeStateHMM.cpp
@@ -276,7 +276,10 @@ ThreeStateHMM::estimate_state_posterior(const size_t start, const size_t end) {
   vector<double> hypo_evidence(end - start, 0), HYPER_evidence(end - start, 0),
     HYPO_evidence(end - start, 0);
 
-  double prev_denom(0), denom(0);
+#ifndef NDEBUG
+  double prev_denom = 0.0;
+#endif
+  double denom = 0.0;
   for (size_t i = start; i < end; ++i) {
     hypo_evidence[i - start] = forward[i].hypo + backward[i].hypo;
     HYPER_evidence[i - start] = forward[i].HYPER + backward[i].HYPER;
@@ -286,7 +289,9 @@ ThreeStateHMM::estimate_state_posterior(const size_t start, const size_t end) {
                         HYPO_evidence[i - start]);
 
     if (i > start) assert(fabs(exp(prev_denom - denom) - 1) < 1e-6);
+#ifndef NDEBUG
     prev_denom = denom;
+#endif
   }
 
   for (size_t i = start; i < end; ++i) {
@@ -407,8 +412,10 @@ ThreeStateHMM::single_iteration() {
   for (size_t i = 0; i < reset_points.size() - 1; ++i) {
     const double forward_score =
       forward_algorithm(reset_points[i], reset_points[i + 1]);
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1]);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1]);
 
     assert(fabs((forward_score - backward_score) /
                 max(forward_score, backward_score)) < 1e-10);
@@ -491,8 +498,10 @@ ThreeStateHMM::PosteriorDecoding() {
   for (size_t i = 0; i < reset_points.size() - 1; ++i) {
     const double forward_score =
       forward_algorithm(reset_points[i], reset_points[i + 1]);
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1]);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1]);
 
     assert(fabs((forward_score - backward_score) /
                 max(forward_score, backward_score)) < 1e-10);

--- a/src/common/TwoStateHMM.cpp
+++ b/src/common/TwoStateHMM.cpp
@@ -355,10 +355,12 @@ single_iteration(const vector<pair<double, double> > &values,
                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
                         fg_emit, bg_emit, forward);
 
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1],
-                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
-                         fg_emit, bg_emit, backward);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1],
+                       lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
+                       fg_emit, bg_emit, backward);
 
     assert(fabs(score - backward_score)/max(score, backward_score) < tolerance);
 
@@ -492,7 +494,7 @@ TwoStateHMM::BaumWelchTraining(const vector<pair<double, double> > &values,
     // ADS: removing the check based on expected log likelihood from
     // forward/backward as these seem to have some problem...
     converged = ((get_delta(p_fb_est, p_fb) < tolerance) &&
-		 (get_delta(p_bf_est, p_bf) < tolerance));
+                 (get_delta(p_bf_est, p_bf) < tolerance));
     // converged = (get_delta(prev_total, total) < tolerance);
 
     if (converged) {
@@ -542,10 +544,12 @@ TwoStateHMM::PosteriorScores(const vector<pair<double, double> > &values,
                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
                         fg_emit, bg_emit, forward);
 
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1],
-                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
-                         fg_emit, bg_emit, backward);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1],
+                       lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
+                       fg_emit, bg_emit, backward);
 
     assert(fabs(score - backward_score)/max(score, backward_score) < tolerance);
 
@@ -623,10 +627,12 @@ TwoStateHMM::TransitionPosteriors(const vector<pair<double, double> > &values,
                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
                         fg_emit, bg_emit, forward);
 
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1],
-                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
-                         fg_emit, bg_emit, backward);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1],
+                       lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
+                       fg_emit, bg_emit, backward);
 
     assert(fabs(score - backward_score)/max(score, backward_score) < tolerance);
 
@@ -686,10 +692,12 @@ TwoStateHMM::PosteriorDecoding(const vector<pair<double, double> > &values,
                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
                         fg_emit, bg_emit, forward);
 
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1],
-                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
-                         fg_emit, bg_emit, backward);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1],
+                       lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
+                       fg_emit, bg_emit, backward);
 
     assert(fabs(score - backward_score)/max(score, backward_score) < tolerance);
 
@@ -930,10 +938,12 @@ single_iteration_rep(const vector<vector<pair<double, double> > > &values,
                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
                         fg_emit, bg_emit, forward);
 
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1],
-                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
-                         fg_emit, bg_emit, backward);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1],
+                       lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
+                       fg_emit, bg_emit, backward);
 
     assert(fabs(score - backward_score)/max(score, backward_score) < tolerance);
 
@@ -1023,7 +1033,7 @@ TwoStateHMM::BaumWelchTraining(const vector<vector<pair<double, double> > > &val
     // ADS: removing the check based on expected log likelihood from
     // forward/backward as these seem to have some problem...
     converged = ((get_delta(p_fb_est, p_fb) < tolerance) &&
-		 (get_delta(p_bf_est, p_bf) < tolerance));
+                 (get_delta(p_bf_est, p_bf) < tolerance));
     // converged = (get_delta(prev_total, total) < tolerance);
 
     if (converged) {
@@ -1071,10 +1081,12 @@ TwoStateHMM::PosteriorScores(const vector<vector<pair<double, double> > > &value
                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
                         fg_emit, bg_emit, forward);
 
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1],
-                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
-                         fg_emit, bg_emit, backward);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1],
+                       lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
+                       fg_emit, bg_emit, backward);
 
     assert(fabs(score - backward_score)/max(score, backward_score) < tolerance);
 
@@ -1119,10 +1131,12 @@ TwoStateHMM::PosteriorDecoding(const vector<vector<pair<double, double> > > &val
                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
                         fg_emit, bg_emit, forward);
 
+#ifndef NDEBUG
     const double backward_score =
-      backward_algorithm(reset_points[i], reset_points[i + 1],
-                         lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
-                         fg_emit, bg_emit, backward);
+#endif
+    backward_algorithm(reset_points[i], reset_points[i + 1],
+                       lp_sf, lp_sb, lp_ff, lp_fb, lp_bf, lp_bb,
+                       fg_emit, bg_emit, backward);
 
     assert(fabs(score - backward_score)/max(score, backward_score) < tolerance);
 

--- a/src/common/TwoStateHMM_PMD.hpp
+++ b/src/common/TwoStateHMM_PMD.hpp
@@ -60,21 +60,22 @@ public:
                         const std::vector<double> fg_alpha, const std::vector<double> fg_beta,
                         const std::vector<double> bg_alpha, const std::vector<double> bg_beta,
                         std::vector<bool> &classes,
-                        std::vector<double> &llr_scores,
+      std::vector<double> &llr_scores,
       const std::vector<bool> &array_status) const;
 
-  void
-  PosteriorScores_rep(
-          const std::vector<std::vector<std::pair<double, double> > > &values,
-                      const std::vector<size_t> &reset_points,
-                      const std::vector<double> &start_trans,
-                      const std::vector<std::vector<double> > &trans,
-                      const std::vector<double> &end_trans,
-                      const std::vector<double> fg_alpha, const std::vector<double> fg_beta,
-                      const std::vector<double> bg_alpha, const std::vector<double> bg_beta,
-                      const std::vector<bool> &classes,
-                      std::vector<double> &llr_scores,
-          const std::vector<bool> &array_status) const;
+  void PosteriorScores_rep(
+    const std::vector<std::vector<std::pair<double, double>>> &values,
+    const std::vector<size_t> &reset_points,
+    const std::vector<double> &start_trans,
+    const std::vector<std::vector<double>> &trans,
+    const std::vector<double> &end_trans,
+    const std::vector<double> fg_alpha,
+    const std::vector<double> fg_beta,
+    const std::vector<double> bg_alpha,
+    const std::vector<double> bg_beta,
+    const std::vector<bool> &classes,
+    std::vector<double> &llr_scores,
+    const std::vector<bool> &array_status) const;
 
   void
   TransitionPosteriors_rep(
@@ -138,8 +139,7 @@ private:
                         const double lp_bf, const double lp_bb, const double lp_bt,
                         const std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
                         const std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
-                        std::vector<std::pair<double, double> > &f,
-      const std::vector<bool> &array_status) const;
+                        std::vector<std::pair<double, double> > &f) const;
 
   double
   backward_algorithm_rep(
@@ -150,26 +150,23 @@ private:
                          const double lp_bf, const double lp_bb, const double lp_bt,
                          const std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
                          const std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
-                         std::vector<std::pair<double, double> > &b,
-       const std::vector<bool> &array_status) const;
+                         std::vector<std::pair<double, double> > &b) const;
 
   void
   estimate_transitions_rep(
          const std::vector<std::vector<std::pair<double, double> > > &vals,
-                           const size_t start, const size_t end,
-                           const std::vector<std::pair<double, double> > &f,
-                           const std::vector<std::pair<double, double> > &b,
-                           const double total,
-                           const std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
-                           const std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
-                           const double lp_ff, const double lp_fb,
-                           const double lp_bf, const double lp_bb,
-                           const double lp_ft, const double lp_bt,
-                           std::vector<double> &ff_vals,
-                           std::vector<double> &fb_vals,
-                           std::vector<double> &bf_vals,
-                           std::vector<double> &bb_vals,
-         const std::vector<bool> &array_status) const;
+         const size_t start, const size_t end,
+         const std::vector<std::pair<double, double> > &f,
+         const std::vector<std::pair<double, double> > &b,
+         const double total,
+         const std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
+         const std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
+         const double lp_ff, const double lp_fb,
+         const double lp_bf, const double lp_bb,
+         std::vector<double> &ff_vals,
+         std::vector<double> &fb_vals,
+         std::vector<double> &bf_vals,
+         std::vector<double> &bb_vals) const;
 
   double
   single_iteration_rep(
@@ -183,8 +180,7 @@ private:
                        double &p_ff, double &p_fb, double &p_ft,
                        double &p_bf, double &p_bb, double &p_bt,
                        std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
-                       std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
-           const std::vector<bool> &array_status) const;
+                       std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro) const;
 
 
   double
@@ -201,42 +197,35 @@ private:
   void
   PosteriorScores_rep(
           const std::vector<std::vector<std::pair<double, double> > > &values,
-                      const std::vector<size_t> &reset_points,
-                      double p_sf, double p_sb,
-                      double p_ff, double p_fb, double p_ft,
-                      double p_bf, double p_bb, double p_bt,
-                      const std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
-                      const std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
-                      const std::vector<bool> &classes,
-                      std::vector<double> &llr_scores,
-          const std::vector<bool> &array_status) const;
+          const std::vector<size_t> &reset_points,
+          double p_sf, double p_sb,
+          double p_ff, double p_fb, double p_ft,
+          double p_bf, double p_bb, double p_bt,
+          const std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
+          const std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
+          const std::vector<bool> &classes,
+          std::vector<double> &llr_scores) const;
 
-  double
-  PosteriorDecoding_rep(
-      const std::vector< std::vector<std::pair<double, double> > > &values,
-                        const std::vector<size_t> &reset_points,
-                        double p_sf, double p_sb,
-                        double p_ff, double p_fb, double p_ft,
-                        double p_bf, double p_bb, double p_bt,
-                        const std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
-                        const std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
-                        std::vector<bool> &classes,
-                        std::vector<double> &llr_scores,
-      const std::vector<bool> &array_status) const;
+  double PosteriorDecoding_rep(
+    const std::vector<std::vector<std::pair<double, double>>> &values,
+    const std::vector<size_t> &reset_points, double p_sf, double p_sb,
+    double p_ff, double p_fb, double p_ft, double p_bf, double p_bb,
+    double p_bt,
+    const std::vector<std::unique_ptr<EmissionDistribution>> &fg_distro,
+    const std::vector<std::unique_ptr<EmissionDistribution>> &bg_distro,
+    std::vector<bool> &classes, std::vector<double> &llr_scores) const;
 
-  void
-  TransitionPosteriors_rep(
-      const std::vector< std::vector<std::pair<double, double> > > &values,
-      const std::vector<size_t> &reset_points,
-      double p_sf, double p_sb,
-      double p_ff, double p_fb, double p_ft,
-      double p_bf, double p_bb, double p_bt,
-      const std::vector<std::unique_ptr<EmissionDistribution> > &fg_distro,
-      const std::vector<std::unique_ptr<EmissionDistribution> > &bg_distro,
-      const size_t transition, const std::vector<bool> &array_status,
-      std::vector<double> &scores) const;
-
-
+  void TransitionPosteriors_rep(
+    const std::vector<std::vector<std::pair<double, double>>> &values,
+    const std::vector<size_t> &reset_points,
+    double p_sf, double p_sb,
+    double p_ff, double p_fb,
+    double p_ft, double p_bf,
+    double p_bb, double p_bt,
+    const std::vector<std::unique_ptr<EmissionDistribution>> &fg_distro,
+    const std::vector<std::unique_ptr<EmissionDistribution>> &bg_distro,
+    const size_t transition,
+    std::vector<double> &scores) const;
 
   /***************************/
 

--- a/src/utils/format-reads.cpp
+++ b/src/utils/format-reads.cpp
@@ -58,7 +58,7 @@ using std::vector;
 using bamxx::bam_rec;
 
 static int32_t
-merge_mates(const size_t range, bam_rec &one, bam_rec &two, bam_rec &merged) {
+merge_mates(bam_rec &one, bam_rec &two, bam_rec &merged) {
   if (!are_mates(one, two)) return -std::numeric_limits<int32_t>::max();
 
   // arithmetic easier using base 0 so subtracting 1 from pos
@@ -345,7 +345,7 @@ format(const string &cmd, const size_t n_threads, const string &inputfile,
       if (same_name(prev_aln, aln, suff_len)) {
         // below: essentially check for dovetail
         if (!bam_is_rev(aln)) swap(prev_aln, aln);
-        const auto frag_len = merge_mates(max_frag_len, prev_aln, aln, merged);
+        const auto frag_len = merge_mates(prev_aln, aln, merged);
         if (frag_len > 0 && frag_len < max_frag_len) {
           if (is_a_rich(merged)) flip_conversion(merged);
           if (!out.write(hdr, merged)) throw bam_write_err;

--- a/src/utils/uniq.cpp
+++ b/src/utils/uniq.cpp
@@ -86,9 +86,9 @@ struct uniq_summary {
     unique_reads = rs_out.reads;
     unique_read_bases = rs_out.bases;
     reads_removed = rs_in.reads - rs_out.reads;
-    non_duplicate_fraction = static_cast<double>(rs_out.reads - reads_duped) / 
+    non_duplicate_fraction = static_cast<double>(rs_out.reads - reads_duped) /
                              std::max(1ul, rs_in.reads);
-    duplication_rate = static_cast<double>(reads_removed + reads_duped) / 
+    duplication_rate = static_cast<double>(reads_removed + reads_duped) /
                        std::max(1ul, reads_duped);
     duplicate_reads = reads_duped;
   }
@@ -97,18 +97,18 @@ struct uniq_summary {
   size_t total_reads{};
   // total_bases is the total number of input bases
   size_t total_bases{};
-  // unique_reads is the number of unique reads 
+  // unique_reads is the number of unique reads
   size_t unique_reads{};
   // unique_read_bases is the total number of bases for the unique reads
   size_t unique_read_bases{};
-  // non_duplicate_fraction is the ratio of the number of unique reads with 
-  // no duplicates to that of the input reads 
+  // non_duplicate_fraction is the ratio of the number of unique reads with
+  // no duplicates to that of the input reads
   double non_duplicate_fraction{};
   // duplicate_reads is the number of unique reads with at least one duplicate
   size_t duplicate_reads{};
   // reads_removed is the number of duplicate reads that have been removed
   size_t reads_removed{};
-  // duplication_rate is the average number of duplicates for the reads with 
+  // duplication_rate is the average number of duplicates for the reads with
   // at least one duplicate (>1 by definition)
   double duplication_rate{};
 
@@ -197,7 +197,7 @@ process_buffer(const bool add_dup_count, rd_stats &rs_out, size_t &reads_duped,
 }
 
 static void
-uniq(const bool VERBOSE, const bool add_dup_count, const size_t n_threads,
+uniq(const bool add_dup_count, const size_t n_threads,
      const string &cmd, const string &infile, const string &statfile,
      const string &histfile, const bool bam_format, const string &outfile) {
   // values to tabulate stats; no real cost
@@ -344,7 +344,7 @@ main_uniq(int argc, const char **argv) {
            << "[command line: \"" << cmd.str() << "\"]" << endl
            << "[random number seed: " << the_seed << "]" << endl;
 
-    uniq(VERBOSE, add_dup_count, n_threads, cmd.str(), infile, statfile,
+    uniq(add_dup_count, n_threads, cmd.str(), infile, statfile,
          histfile, bam_format, outfile);
   }
   catch (const runtime_error &e) {


### PR DESCRIPTION
- EpireadStats: removing constexpr as it's not always supported yet for the way it was used
- bsrate: adding to_string around an integer that was concatenated to a string
- MSite.cpp: putting a guard around use of from_chars because on osx it is not yet available from c++17
- amrfinder.cpp: ensuring move is std::move because it must be explicit fir some compilers. Also casting properly for size_t seeming to be unsigned long long on apple
- Removing unused variables to silence warnings. In some cases these seem to have been important
- amrfinder: Fixing a warning issues by using decltype in a static cast
- ThreeStateHMM: putting guards around backward score as it's only used to compare with forward score in debug situation within assert
- Fixes #169.
- pmd: many places the vector indicating array_status had been passed around despite only being used in a few of those places. These were deleted
