### PR TITLE
amrfinder correct for read counts

### DIFF
--- a/data/md5sum.txt
+++ b/data/md5sum.txt
@@ -13,10 +13,10 @@ af8b97ef25af8a16ced1537ca4a74d07  tests/reads.hmr
 1aecbb2b12bd867405118eae42de6743  tests/reads.ustats
 bcbf01be810cbf4051292813eb6b9225  tests/tRex1.idx
 7c84dafb85252a04a45704da71eba7c4  tests/tRex1_promoters.roi.bed
-e7e9590475a7f9b1ae41701d81892e57  tests/two_epialleles.amr
 ec6a686617cad31e9f7a37a3d378e6ed  tests/two_epialleles.states
 93e38b20d162062a5d147c4290095a13  tests/mlml.out
 d947fe3d61ef7b1564558a69608f0e64  tests/methylome.pmd
 7d481d31e4316e97d519838f4887b10d  tests/reads.sam
 466e2715f0c677593e84b3790efbec6e  tests/reads.fmt.sam
 5583ebe1b689159f8eb0a93f32e2fd48  tests/reads.fmt.srt.uniq.sam
+d41d8cd98f00b204e9800998ecf8427e  tests/two_epialleles.amr

--- a/src/amrfinder/amrfinder.cpp
+++ b/src/amrfinder/amrfinder.cpp
@@ -410,6 +410,7 @@ main_amrfinder(int argc, const char **argv) {
     bool use_bic = false;
     bool use_fdr = true;
     bool apply_correction = false;
+    bool correct_for_read_count = true;
 
     /****************** COMMAND LINE OPTIONS ********************/
     OptionParser opt_parse(strip_path(argv[0]), description, "<epireads>");
@@ -428,6 +429,8 @@ main_amrfinder(int argc, const char **argv) {
     opt_parse.add_opt("pvals", 'h', "adjusts p-values using Hochberg step-up",
                       false, apply_correction);
     opt_parse.add_opt("nofdr", 'f', "omits FDR procedure", false, use_fdr);
+    opt_parse.add_opt("nordc", 'r', "turn off read count correction",
+                      false, correct_for_read_count);
     opt_parse.add_opt("bic", 'b', "use BIC to compare models", false, use_bic);
     opt_parse.add_opt("summary", 'S', "write summary output here", false,
                       summary_file);
@@ -467,6 +470,8 @@ main_amrfinder(int argc, const char **argv) {
 
     const auto epistat =
       EpireadStats(low_prob, high_prob, critical_value, max_itr, use_bic);
+
+    EpireadStats::set_read_count_correction(correct_for_read_count);
 
     // bamxx::bam_tpool tp(n_threads);
     bgzf_file in(reads_file, "r");
@@ -510,7 +515,7 @@ main_amrfinder(int argc, const char **argv) {
     // windows_accepted is the number of sliding windows in the
     // methylome that were found to have a significant signal of
     // allele-specific methylation
-    const auto windows_accepted = amrs.size();
+    const auto windows_accepted = size(amrs);
     if (!amrs.empty()) {
       /*
         ADS: there are several "steps" below that are done
@@ -560,7 +565,7 @@ main_amrfinder(int argc, const char **argv) {
       // collapsed_amrs is the number of intervals of consecutive CpG
       // sites that are found to reside in a window among those
       // accepted as significant
-      const auto collapsed_amrs = amrs.size();
+      const auto n_collapsed_amrs = size(amrs);
 
       if (!convert_coordinates(genome_file, amrs)) {
         cerr << "failed converting coordinates" << endl;
@@ -575,7 +580,7 @@ main_amrfinder(int argc, const char **argv) {
       // merged_amrs are the number of intervals that result from
       // merging any collapsed amrs that have a distance of less than
       // gap_limit/2 from each other
-      const auto merged_amrs = amrs.size();
+      const auto n_merged_amrs = size(amrs);
 
       // if BIC was not requested, then eliminate AMRs based on either
       // the p-value cutoff, or with the FDR-based cutoff, if it was
@@ -588,7 +593,7 @@ main_amrfinder(int argc, const char **argv) {
                    cend(amrs));
       }
 
-      const auto amrs_passing_fdr = amrs.size();
+      const auto amrs_passing_fdr = size(amrs);
 
       // ADS: eliminating AMRs based on their size makes sense, but
       // not if that size is tied to the gap between AMRs we would
@@ -601,8 +606,8 @@ main_amrfinder(int argc, const char **argv) {
       if (verbose) {
         cerr << "windows_tested: " << windows_tested << '\n'
              << "windows_accepted: " << windows_accepted << '\n'
-             << "collapsed_amrs: " << collapsed_amrs << '\n'
-             << "merged_amrs: " << merged_amrs << '\n';
+             << "collapsed_amrs: " << n_collapsed_amrs << '\n'
+             << "merged_amrs: " << n_merged_amrs << '\n';
         if (use_fdr)
           cerr << "fdr_cutoff: " << fdr_cutoff << '\n'
                << "amrs_passing_fdr: " << amrs_passing_fdr << '\n';

--- a/src/amrfinder/amrfinder.cpp
+++ b/src/amrfinder/amrfinder.cpp
@@ -468,10 +468,8 @@ main_amrfinder(int argc, const char **argv) {
            << "[test=" << (use_bic ? "BIC" : "LRT") << "] "
            << "[iterations=" << max_itr << "]" << endl;
 
-    const auto epistat =
-      EpireadStats(low_prob, high_prob, critical_value, max_itr, use_bic);
-
-    EpireadStats::set_read_count_correction(correct_for_read_count);
+    const EpireadStats epistat{low_prob, high_prob, critical_value,
+                               max_itr, use_bic, correct_for_read_count};
 
     // bamxx::bam_tpool tp(n_threads);
     bgzf_file in(reads_file, "r");

--- a/src/common/EpireadStats.cpp
+++ b/src/common/EpireadStats.cpp
@@ -302,7 +302,8 @@ compute_model_likelihoods(double &single_score, double &pair_score,
 
 
 double
-test_asm_lrt(const size_t max_itr, const double low_prob,
+test_asm_lrt(const size_t max_itr, const bool correct_for_read_count,
+             const double low_prob,
              const double high_prob, vector<epi_r> &reads) {
   double single_score = num_lim<double>::min();
   double pair_score = num_lim<double>::min();
@@ -319,14 +320,20 @@ test_asm_lrt(const size_t max_itr, const double low_prob,
   // minus n_cpgs for one-allele model
   const size_t df = n_cpgs;
 
+  // correction for numbers of reads
+  if (correct_for_read_count)
+    pair_score += size(reads)*log(0.5);
+
   const double llr_stat = -2*(single_score - pair_score);
   const double p_value = 1.0 - gsl_cdf_chisq_P(llr_stat, df);
+
   return p_value;
 }
 
 
 double
-test_asm_bic(const size_t max_itr, const double low_prob,
+test_asm_bic(const size_t max_itr, const bool correct_for_read_count,
+             const double low_prob,
              const double high_prob, vector<epi_r> &reads) {
 
   double single_score = num_lim<double>::min();
@@ -336,6 +343,10 @@ test_asm_bic(const size_t max_itr, const double low_prob,
 
   compute_model_likelihoods(single_score, pair_score, max_itr, low_prob,
                             high_prob, n_cpgs, reads);
+
+  // correction for numbers of reads
+  if (correct_for_read_count)
+    pair_score += size(reads)*log(0.5);
 
   for (auto &read : reads)
     read.pos += first_read_offset;

--- a/src/common/EpireadStats.hpp
+++ b/src/common/EpireadStats.hpp
@@ -17,38 +17,31 @@
 #ifndef EPIREAD_STATS
 #define EPIREAD_STATS
 
-#include "Epiread.hpp"
-#include <vector>
 #include <cstdint>
+#include <vector>
+
+#include "Epiread.hpp"
 
 struct small_epiread {
   uint32_t pos{};
   std::string seq{};
-  small_epiread(uint32_t p, std::string s) : pos{p}, seq{s} {}
-  uint32_t end() const {return pos + std::size(seq);}
-  uint32_t length() const {return std::size(seq);}
+
+  small_epiread(uint32_t p, std::string s): pos{p}, seq{s} {}
+
+  uint32_t end() const { return pos + std::size(seq); }
+
+  uint32_t length() const { return std::size(seq); }
 };
-
-
-////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////
-//////
-//////  FUNCTIONS FOR A SINGLE EPITYPE
-//////
 
 double
 log_likelihood(const small_epiread &r, const std::vector<double> &a);
+
 void
 fit_epiallele(const std::vector<small_epiread> &reads,
               const std::vector<double> &indicators, std::vector<double> &a);
 double
-fit_single_epiallele(const std::vector<small_epiread> &reads, std::vector<double> &a);
-
-////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////
-//////
-//////  FUNCTIONS FOR TWO EPITYPES
-//////
+fit_single_epiallele(const std::vector<small_epiread> &reads,
+                     std::vector<double> &a);
 
 double
 log_likelihood(const small_epiread &r, const double z,
@@ -57,48 +50,43 @@ double
 log_likelihood(const small_epiread &r, const std::vector<double> &a1,
                const std::vector<double> &a2);
 double
-log_likelihood(const std::vector<small_epiread> &reads, const std::vector<double> &indicators,
+log_likelihood(const std::vector<small_epiread> &reads,
+               const std::vector<double> &indicators,
                const std::vector<double> &a1, const std::vector<double> &a2);
 
 double
 resolve_epialleles(const size_t max_itr,
                    const std::vector<small_epiread> &reads,
-                   std::vector<double> &indicators,
-                   std::vector<double> &a1, std::vector<double> &a2);
+                   std::vector<double> &indicators, std::vector<double> &a1,
+                   std::vector<double> &a2);
 
 double
-test_asm_lrt(const size_t max_itr, const double low_prob,
-             const double high_prob, std::vector<small_epiread> &reads);
+test_asm_lrt(const size_t max_itr, const bool crct_for_read_count,
+             const double low_prob, const double high_prob,
+             std::vector<small_epiread> &reads);
 
 double
-test_asm_bic(const size_t max_itr, const double low_prob,
-             const double high_prob, std::vector<small_epiread> &reads);
+test_asm_bic(const size_t max_itr, const bool crct_for_read_count,
+             const double low_prob, const double high_prob,
+             std::vector<small_epiread> &reads);
 
-
-class EpireadStats {
-public:
-  EpireadStats(const double lp,
-               const double hp,
-               const double cv,
-               const size_t mi,
-               const bool ub) :
-    low_prob{lp}, high_prob{hp},
-    critical_value{cv}, max_itr{mi}, use_bic{ub} {}
-
-  double
-  test_asm(std::vector<small_epiread> &reads, bool &is_significant) const {
-    const double score = use_bic
-      ? test_asm_bic(max_itr, low_prob, high_prob, reads)
-      : test_asm_lrt(max_itr, low_prob, high_prob, reads);
+struct EpireadStats {
+  double test_asm(std::vector<small_epiread> &reads,
+                  bool &is_significant) const {
+    const double score = use_bic ? test_asm_bic(max_itr, crct_for_read_count,
+                                                low_prob, high_prob, reads)
+                                 : test_asm_lrt(max_itr, crct_for_read_count,
+                                                low_prob, high_prob, reads);
     is_significant = use_bic ? score < 0.0 : score < critical_value;
     return score;
   }
-private:
-  double low_prob{};
-  double high_prob{};
-  double critical_value{};
-  size_t max_itr{};
-  bool use_bic{};
+
+  double low_prob{0.25};
+  double high_prob{0.75};
+  double critical_value{0.01};
+  size_t max_itr{10};
+  bool use_bic{false};
+  bool crct_for_read_count{true};
 };
 
 #endif


### PR DESCRIPTION
- smithlab_cpp: updating submodule
- amrfinder: added an option to turn off the correction to likelihood for the number of reads which is applied to the likelihood for the two alleles model
- EpireadStats.hpp: changing the EpireadStats class to struct and allowing default values for default constructor. Also adding an instance variable to indicate whether log likelihood for allel pair model should correct for number of reads
- EpireadStats.cpp: adding a variable to control the use of correction to the allele pair model log likelihood based on number of reads
- amrfinder.cpp: Using the default constructor for EpireadStats
- amrtester: using an approach more similar to amrfinder which uses the EpireadStats class instance and allows a correction for read count for the allel pair model log likelihood
- amrtester: more changes
- md5sum: update for the empty amr file output by amrfinder currently
