### PR TITLE
compress counts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -218,6 +218,7 @@ dnmtools_SOURCES += src/utils/covered.cpp
 dnmtools_SOURCES += src/utils/recovered.cpp
 dnmtools_SOURCES += src/utils/kmersites.cpp
 dnmtools_SOURCES += src/utils/xcounts.cpp
+dnmtools_SOURCES += src/utils/unxcounts.cpp
 
 dnmtools_SOURCES += src/amrfinder/allelicmeth.cpp
 dnmtools_SOURCES += src/amrfinder/amrfinder.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -217,6 +217,7 @@ dnmtools_SOURCES += src/utils/fast-liftover.cpp
 dnmtools_SOURCES += src/utils/covered.cpp
 dnmtools_SOURCES += src/utils/recovered.cpp
 dnmtools_SOURCES += src/utils/kmersites.cpp
+dnmtools_SOURCES += src/utils/xcounts.cpp
 
 dnmtools_SOURCES += src/amrfinder/allelicmeth.cpp
 dnmtools_SOURCES += src/amrfinder/amrfinder.cpp

--- a/src/common/MSite.cpp
+++ b/src/common/MSite.cpp
@@ -34,14 +34,13 @@ using std::cbegin;
 using std::cend;
 using std::end;
 
-MSite::MSite(const string &line) {
+
+bool
+MSite::initialize(const char *c, const char *c_end) {
   constexpr auto is_sep = [](const char x) { return x == ' ' || x == '\t'; };
   constexpr auto not_sep = [](const char x) { return x != ' ' && x != '\t'; };
 
   bool failed = false;
-
-  const auto c = line.data();
-  const auto c_end = c + line.size();
 
   auto field_s = c;
   auto field_e = find_if(field_s + 1, c_end, is_sep);
@@ -97,13 +96,24 @@ MSite::MSite(const string &line) {
     const auto [ptr, ec] = from_chars(field_s, c_end, n_reads);
     failed = failed || (ptr != c_end);
   }
+  // ADS: the value below would work for a flag
+  // pos = std::numeric_limits<decltype(pos)>::max();
 
-  if (failed) {
-    throw runtime_error("bad count line: " + line);
-    // ADS: the value below would work for a flag
-    // pos = std::numeric_limits<decltype(pos)>::max();
-  }
+  return !failed;
 }
+
+
+MSite::MSite(const string &line) {
+  if (!initialize(line.data(), line.data() + size(line)))
+    throw runtime_error("bad count line: " + line);
+}
+
+
+MSite::MSite(const char *line, const int n) {
+  if (!initialize(line, line + n))
+    throw runtime_error("bad count line: " + string(line));
+}
+
 
 string
 MSite::tostring() const {

--- a/src/common/MSite.hpp
+++ b/src/common/MSite.hpp
@@ -35,6 +35,9 @@ struct MSite {
     chrom(_chrom), pos(_pos), strand(_strand),
     context(_context), meth(_meth), n_reads(_n_reads) {}
   explicit MSite(const std::string &line);
+  explicit MSite(const char *line, const int n);
+
+  bool initialize(const char *c, const char *c_end);
 
   std::string chrom;
   size_t pos;

--- a/src/common/bam_record_utils.hpp
+++ b/src/common/bam_record_utils.hpp
@@ -263,6 +263,11 @@ sam_hdr_tid2name(const bamxx::bam_header &hdr, const int32_t tid) {
   return std::string(sam_hdr_tid2name(hdr.h, tid));
 }
 
+inline uint32_t
+sam_hdr_tid2len(const bamxx::bam_header &hdr, const int32_t tid) {
+  return sam_hdr_tid2len(hdr.h, tid);
+}
+
 inline std::string
 sam_hdr_tid2name(const bamxx::bam_header &hdr, const bamxx::bam_rec &aln) {
   return std::string(sam_hdr_tid2name(hdr.h, aln.b->core.tid));

--- a/src/dnmtools.cpp
+++ b/src/dnmtools.cpp
@@ -130,6 +130,8 @@ main_covered(int argc, const char **argv);
 int
 main_xcounts(int argc, const char **argv);
 int
+main_unxcounts(int argc, const char **argv);
+int
 main_recovered(int argc, const char **argv);
 int
 kmersites(int argc, const char **argv);
@@ -203,6 +205,7 @@ main(int argc, const char **argv) {
    {"covered",       "filter a counts file for only covered sites", main_covered},
    {"recovered",     "replace missing sites in a counts file", main_recovered},
    {"xcounts",       "compress counts files by removing information", main_xcounts},
+   {"unxcounts",     "reverse the xcounts process yielding a counts file", main_unxcounts},
    {"selectsites",   "sites inside a set of genomic intervals", main_selectsites},
    {"kmersites",     "make track file for sites matching kmer", kmersites}}}}}};
 // clang-format on

--- a/src/dnmtools.cpp
+++ b/src/dnmtools.cpp
@@ -128,6 +128,8 @@ metagene(int argc, const char **argv);
 int
 main_covered(int argc, const char **argv);
 int
+main_xcounts(int argc, const char **argv);
+int
 main_recovered(int argc, const char **argv);
 int
 kmersites(int argc, const char **argv);
@@ -200,6 +202,7 @@ main(int argc, const char **argv) {
    {"merge",         "merge multiple counts files into a counts file or a table", main_merge_methcounts},
    {"covered",       "filter a counts file for only covered sites", main_covered},
    {"recovered",     "replace missing sites in a counts file", main_recovered},
+   {"xcounts",       "compress counts files by removing information", main_xcounts},
    {"selectsites",   "sites inside a set of genomic intervals", main_selectsites},
    {"kmersites",     "make track file for sites matching kmer", kmersites}}}}}};
 // clang-format on

--- a/src/utils/covered.cpp
+++ b/src/utils/covered.cpp
@@ -81,7 +81,7 @@ main_covered(int argc, const char **argv) {
 
     /****************** COMMAND LINE OPTIONS ********************/
     OptionParser opt_parse(strip_path(argv[0]), description,
-                           "<methcounts-file> (\"-\" for standard input)", 1);
+                           "<counts-file> (\"-\" for standard input)", 1);
     opt_parse.add_opt("output", 'o', "output file (default is standard out)",
                       false, outfile);
     opt_parse.add_opt("threads", 't', "threads for compression (use few)",

--- a/src/utils/recovered.cpp
+++ b/src/utils/recovered.cpp
@@ -67,6 +67,7 @@ verify_chrom_orders(const bool verbose, const uint32_t n_threads,
   int32_t prev_idx = -1;
 
   while (getline(in, line)) {
+    if (line[0] == '#') continue;
     line.resize(line.find_first_of(" \t"));
     if (line != prev_chrom) {
       if (verbose) cerr << "verifying: " << line << endl;
@@ -273,8 +274,11 @@ process_sites(const bool verbose, const bool add_missing_chroms,
   // ADS: this is probably a poor strategy since we already would know
   // the index of the chrom sequence in the vector.
   chrom_itr_t chrom_itr;
+  string line;
 
-  while (read_site(in, site)) {
+  while (getline(in, line)) {
+    if (line[0] == '#') continue;
+    site.initialize(line.data(), line.data() + size(line));
     if (site.chrom != chrom_name) {
 
       if (pos != num_lim<uint64_t>::max())

--- a/src/utils/unxcounts.cpp
+++ b/src/utils/unxcounts.cpp
@@ -1,0 +1,414 @@
+/* unxcounts: reverse the process of xcounts and generate the counts
+ * file, including sites not covered.
+ *
+ * Copyright (C) 2023 Andrew D. Smith
+ *
+ * Authors: Andrew D. Smith
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <bamxx.hpp>
+
+// from smithlab_cpp
+#include "OptionParser.hpp"
+#include "smithlab_utils.hpp"
+#include "smithlab_os.hpp"
+#include "bsutils.hpp"
+#include "dnmt_error.hpp"
+
+#include "MSite.hpp"
+
+using std::string;
+using std::vector;
+using std::cout;
+using std::cerr;
+using std::endl;
+using std::unordered_map;
+using std::unordered_set;
+using std::pair;
+using std::numeric_limits;
+using std::runtime_error;
+
+using bamxx::bgzf_file;
+
+template<typename T> using num_lim = std::numeric_limits<T>;
+
+static void
+verify_chrom_orders(const bool verbose, const uint32_t n_threads,
+                    const string &filename,
+                    const unordered_map<string, int32_t> &chroms_order) {
+  bgzf_file in(filename, "r");
+  if (!in) throw runtime_error("bad file: " + filename);
+
+  bamxx::bam_tpool tp(n_threads);
+  // set the threads for the input file decompression
+  if (n_threads > 1)
+    tp.set_io(in);
+
+  unordered_set<int32_t> chroms_seen;
+  string line;
+  string prev_chrom;
+
+  int32_t prev_idx = -1;
+
+  while (getline(in, line)) {
+    if (line[0] == '#') continue;
+    if (line.find_first_of(" \t") != string::npos) continue;
+    if (line != prev_chrom) {
+      if (verbose) cerr << "verifying: " << line << endl;
+
+      const auto idx_itr = chroms_order.find(line);
+      if (idx_itr == cend(chroms_order))
+        throw runtime_error("chrom not found genome file: " + line);
+      const auto idx = idx_itr->second;
+
+      if (chroms_seen.find(idx) != end(chroms_seen))
+        throw runtime_error("chroms out of order in: " + filename);
+      chroms_seen.insert(idx);
+
+      if (idx < prev_idx)
+        throw runtime_error("inconsistent chromosome order at: " + line);
+
+      prev_idx = idx;
+      std::swap(line, prev_chrom);
+    }
+  }
+  if (verbose) cerr << "chrom orders are consistent" << endl;
+}
+
+struct quick_buf : public std::ostringstream,
+                   public std::basic_stringbuf<char> {
+  // ADS: By user ecatmur on SO; very fast. Seems to work...
+  quick_buf() {
+    // ...but this seems to depend on data layout
+    static_cast<std::basic_ios<char>&>(*this).rdbuf(this);
+  }
+  void clear() {
+    // reset buffer pointers (member functions)
+    setp(pbase(), pbase());
+  }
+  char const* c_str() {
+    /* between c_str and insertion make sure to clear() */
+    *pptr() = '\0';
+    return pbase();
+  }
+};
+
+
+/* The three functions below here should probably be moved into
+   bsutils.hpp. I am not sure if the DDG function is needed, but it
+   seems like if one considers strand, and the CHH is not symmetric,
+   then one needs this. Also, Qiang should be consulted on this
+   because he spent much time thinking about it in the context of
+   plants. */
+static inline bool
+is_chh(const std::string &s, size_t i) {
+  return (i < (s.length() - 2)) &&
+    is_cytosine(s[i]) &&
+    !is_guanine(s[i + 1]) &&
+    !is_guanine(s[i + 2]);
+}
+
+
+static inline bool
+is_ddg(const std::string &s, size_t i) {
+  return (i < (s.length() - 2)) &&
+    !is_cytosine(s[i]) &&
+    !is_cytosine(s[i + 1]) &&
+    is_guanine(s[i + 2]);
+}
+
+
+static inline bool
+is_c_at_g(const std::string &s, size_t i) {
+  return (i < (s.length() - 2)) &&
+    is_cytosine(s[i]) &&
+    !is_cytosine(s[i + 1]) &&
+    !is_guanine(s[i + 1]) &&
+    is_guanine(s[i + 2]);
+}
+
+/* The "tag" returned by this function should be exclusive, so that
+ * the order of checking conditions doesn't matter. There is also a
+ * bit of a hack in that the unsigned "pos" could wrap, but this still
+ * works as long as the chromosome size is not the maximum size of a
+ * size_t.
+ */
+static inline uint32_t
+get_tag_from_genome_c(const string &s, const size_t pos) {
+  if (is_cpg(s, pos)) return 0;
+  else if (is_chh(s, pos)) return 1;
+  else if (is_c_at_g(s, pos)) return 2;
+  return 3;
+}
+
+static inline uint32_t
+get_tag_from_genome_g(const string &s, const size_t pos) {
+  if (is_cpg(s, pos - 1)) return 0;
+  else if (is_ddg(s, pos - 2)) return 1;
+  else if (is_c_at_g(s, pos - 2)) return 2;
+  return 3;
+}
+
+static const char *tag_values[] = {
+  "CpG", // 0
+  "CHH", // 1
+  "CXG", // 2
+  "CCG", // 3
+  "N"    // 4
+};
+
+static void
+write_missing_sites(const string &name, const string &chrom,
+                const uint64_t start_pos, const uint64_t end_pos,
+                bgzf_file &out) {
+  const string name_tab = name + "\t";
+  quick_buf buf;
+  for (auto pos = start_pos; pos < end_pos; ++pos) {
+    const char base = chrom[pos];
+    if (is_cytosine(base) || is_guanine(base)) {
+      const bool is_c = is_cytosine(base);
+      const uint32_t the_tag = is_c ? get_tag_from_genome_c(chrom, pos)
+                                    : get_tag_from_genome_g(chrom, pos);
+      buf.clear();
+      buf << name_tab << pos
+          << (is_c ? "\t+\t" : "\t-\t")
+          << tag_values[the_tag]
+          << "\t0\t0\n";
+      if (!out.write(buf.c_str(), buf.tellp()))
+        throw dnmt_error("error writing output");
+    }
+  }
+}
+
+
+static void
+write_site(const string &name, const string &chrom,
+           const uint32_t pos, const uint32_t n_meth,
+           const uint32_t n_unmeth, bgzf_file &out) {
+  const char base = chrom[pos];
+  assert(is_cytosine(base) || is_guanine(base));
+  const bool is_c = is_cytosine(base);
+  const uint32_t the_tag = is_c ? get_tag_from_genome_c(chrom, pos)
+                                : get_tag_from_genome_g(chrom, pos);
+  const auto n_reads = n_meth + n_unmeth;
+  quick_buf buf;
+  buf << name << '\t' << pos
+      << (is_c ? "\t+\t" : "\t-\t")
+      << tag_values[the_tag] << '\t'
+      << static_cast<double>(n_meth)/std::max(n_reads, 1u) << '\t'
+      << n_reads << '\n';
+  if (!out.write(buf.c_str(), buf.tellp()))
+    throw dnmt_error("error writing output");
+}
+
+// static void
+// write_current_site(const MSite &site, bgzf_file &out) {
+//   quick_buf buf; // keep underlying buffer space?
+//   buf << site << '\n';
+//   if (!out.write(buf.c_str(), buf.tellp()))
+//     throw dnmt_error("error writing site: " + site.tostring());
+// }
+
+typedef vector<string>::const_iterator chrom_itr_t;
+
+static chrom_itr_t
+get_chrom(const unordered_map<string, chrom_itr_t> &chrom_lookup,
+          const string &chrom_name) {
+  const auto chrom_idx = chrom_lookup.find(chrom_name);
+  if (chrom_idx == cend(chrom_lookup))
+    throw dnmt_error("chromosome not found: " + chrom_name);
+  return chrom_idx->second;
+}
+
+static int32_t
+get_chrom_idx(const unordered_map<string, int32_t> &name_to_idx,
+              const string &chrom_name) {
+  const auto chrom_idx = name_to_idx.find(chrom_name);
+  if (chrom_idx == cend(name_to_idx))
+    throw dnmt_error("chromosome not found: " + chrom_name);
+  return chrom_idx->second;
+}
+
+static void
+process_sites(const bool verbose, const bool add_missing_chroms,
+              const bool compress_output, const size_t n_threads,
+              const string &infile, const string &outfile,
+              const string &chroms_file) {
+
+  // first get the chromosome names and sequences from the FASTA file
+  vector<string> chroms, names;
+  read_fasta_file_short_names(chroms_file, names, chroms);
+  for (auto &i : chroms)
+    transform(cbegin(i), cend(i), begin(i),
+              [](const char c) { return std::toupper(c); });
+  if (verbose)
+    cerr << "[n chroms in reference: " << chroms.size() << "]" << endl;
+
+  unordered_map<string, chrom_itr_t> chrom_lookup;
+  unordered_map<string, int32_t> name_to_idx;
+  vector<uint64_t> chrom_sizes(size(chroms), 0);
+  for (size_t i = 0; i < size(chroms); ++i) {
+    chrom_lookup[names[i]] = cbegin(chroms) + i;
+    name_to_idx[names[i]] = i;
+    chrom_sizes[i] = size(chroms[i]);
+  }
+
+  if (add_missing_chroms)
+    verify_chrom_orders(verbose, n_threads, infile, name_to_idx);
+
+  bamxx::bam_tpool tp(n_threads);
+
+  bamxx::bgzf_file in(infile, "r");
+  if (!in) throw dnmt_error("failed to open input file");
+
+  const string output_mode = compress_output ? "w" : "wu";
+  bgzf_file out(outfile, output_mode);
+  if (!out) throw dnmt_error("error opening output file: " + outfile);
+
+  // set the threads for the input file decompression
+  if (n_threads > 1) {
+    tp.set_io(in);
+    tp.set_io(out);
+  }
+
+  string line;
+  MSite site;
+  string chrom_name;
+  int32_t prev_chrom_idx = -1;
+  uint64_t pos = num_lim<uint64_t>::max();
+
+  // ADS: this is probably a poor strategy since we already would know
+  // the index of the chrom sequence in the vector.
+  chrom_itr_t chrom_itr;
+
+  while (getline(in, line)) {
+    if (line[0] == '#') {
+      line += '\n';
+      out.write(line);
+      continue;
+    }
+
+    if (line.find_first_of(" \t") == string::npos) {
+
+      if (pos != num_lim<uint64_t>::max())
+        write_missing_sites(chrom_name, *chrom_itr, pos, size(*chrom_itr), out);
+
+      const int32_t chrom_idx = get_chrom_idx(name_to_idx, line);
+
+      if (add_missing_chroms)
+        for (auto i = prev_chrom_idx + 1; i < chrom_idx; ++i) {
+          if (verbose)
+            cerr << "processing: " << names[i] << " (missing)" << endl;
+          write_missing_sites(names[i], chroms[i], 0u, size(chroms[i]), out);
+        }
+
+      chrom_name = line;
+      chrom_itr = get_chrom(chrom_lookup, chrom_name);
+      pos = 0;
+      prev_chrom_idx = chrom_idx;
+      if (verbose)
+        cerr << "processing: " << chrom_name << endl;
+      site.chrom = chrom_name;
+    }
+    else {
+
+      uint32_t pos_step = 0;
+      uint32_t n_meth = 0;
+      uint32_t n_unmeth = 0;
+
+      std::istringstream iss(line);
+      if (!(iss >> pos_step >> n_meth >> n_unmeth))
+        throw dnmt_error("invalid line: " + line);
+
+      const auto curr_pos = pos + pos_step;
+      if (pos + 1 < curr_pos)
+        write_missing_sites(chrom_name, *chrom_itr, pos + 1, curr_pos, out);
+
+      write_site(chrom_name, *chrom_itr, curr_pos, n_meth, n_unmeth, out);
+      pos = curr_pos;
+    }
+  }
+  write_missing_sites(chrom_name, *chrom_itr, pos, size(*chrom_itr), out);
+
+  if (add_missing_chroms) {
+    const int32_t chrom_idx = size(chroms);
+    for (auto i = prev_chrom_idx + 1; i < chrom_idx; ++i) {
+      if (verbose)
+        cerr << "processing: " << names[i] << " (missing)" << endl;
+      write_missing_sites(names[i], chroms[i], 0u, size(chroms[i]), out);
+    }
+  }
+}
+
+
+int
+main_unxcounts(int argc, const char **argv) {
+  try {
+
+    bool verbose = false;
+    bool add_missing_chroms = false;
+    bool compress_output = false;
+    size_t n_threads = 1;
+
+    string outfile;
+    string chroms_file;
+    const string description =
+      "add sites that are missing as non-covered sites";
+
+    /****************** COMMAND LINE OPTIONS ********************/
+    OptionParser opt_parse(strip_path(argv[0]), description,
+                           "<xcounts-file>");
+    opt_parse.add_opt("output", 'o', "output file (required)", true, outfile);
+    opt_parse.add_opt("missing", 'm', "add missing chroms", false, add_missing_chroms);
+    opt_parse.add_opt("threads", 't', "number of threads", false, n_threads);
+    opt_parse.add_opt("chrom", 'c', "reference genome file (FASTA format)",
+                      true , chroms_file);
+    opt_parse.add_opt("zip", 'z', "output gzip format", false, compress_output);
+    opt_parse.add_opt("verbose", 'v', "print more run info", false, verbose);
+    std::vector<string> leftover_args;
+    opt_parse.parse(argc, argv, leftover_args);
+    if (argc == 1 || opt_parse.help_requested()) {
+      cerr << opt_parse.help_message() << endl
+           << opt_parse.about_message() << endl;
+      return EXIT_SUCCESS;
+    }
+    if (opt_parse.about_requested()) {
+      cerr << opt_parse.about_message() << endl;
+      return EXIT_SUCCESS;
+    }
+    if (opt_parse.option_missing()) {
+      cerr << opt_parse.option_missing_message() << endl;
+      return EXIT_SUCCESS;
+    }
+    if (leftover_args.size() != 1) {
+      cerr << opt_parse.help_message() << endl;
+      return EXIT_SUCCESS;
+    }
+    const string filename(leftover_args.front());
+    /****************** END COMMAND LINE OPTIONS *****************/
+
+    process_sites(verbose, add_missing_chroms, compress_output, n_threads,
+                  filename, outfile, chroms_file);
+  }
+  catch (const std::runtime_error &e) {
+    cerr << e.what() << endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/src/utils/xcounts.cpp
+++ b/src/utils/xcounts.cpp
@@ -71,8 +71,6 @@ fill_output_buffer(const uint32_t offset, const MSite &s, T &buf) {
   *res.ptr++ = '\t';
   res = to_chars(res.ptr, buf_end, s.n_unmeth());
   *res.ptr++ = '\n';
-  *res.ptr = '\0';
-  // if (res.ec != std::errc()) res.ptr = buf.data();
   return std::distance(buf.data(), res.ptr);
 }
 
@@ -136,11 +134,7 @@ main_xcounts(int argc, const char **argv) {
     const int ret = ks_resize(&line, 1024);
     if (ret) throw runtime_error("failed to acquire buffer");
 
-    vector<char> buf(1024);
-
-    // MAKE A HEADER IN THE COMPRESSED COUNTS FILE THAT IDENTIFIES THE
-    // GENOME WITH CHROMOSOME NAMES AND A HASH FOR EACH CHROMOSOME
-    // INCLUDING THE NUMBER OF SITES OF EACH TYPE.
+    vector<char> buf(128);
 
     uint32_t offset = 0;
     string prev_chrom;
@@ -159,7 +153,6 @@ main_xcounts(int argc, const char **argv) {
       if (!status_ok) break;
 
       if (site.chrom != prev_chrom) {
-        cerr << site.chrom << endl;
         prev_chrom = site.chrom;
         offset = 0;
 

--- a/src/utils/xcounts.cpp
+++ b/src/utils/xcounts.cpp
@@ -1,0 +1,187 @@
+/* xcounts: reformat counts so they only give the m and u counts in a
+ * wig format
+ *
+ * Copyright (C) 2023 Andrew D. Smith
+ *
+ * Authors: Andrew D. Smith
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#include <bamxx.hpp>
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <charconv>
+#include <system_error>
+
+// from smithlab_cpp
+#include "OptionParser.hpp"
+#include "smithlab_os.hpp"
+#include "smithlab_utils.hpp"
+#include "MSite.hpp"
+
+using std::cerr;
+using std::cout;
+using std::endl;
+using std::runtime_error;
+using std::string;
+using std::to_chars;
+using std::vector;
+
+using bamxx::bgzf_file;
+
+inline auto
+getline(bgzf_file &file, kstring_t &line) -> bgzf_file & {
+  if (file.f == nullptr) return file;
+  const int x = bgzf_getline(file.f, '\n', &line);
+  if (x == -1) {
+    file.destroy();
+    free(line.s);
+    line = {0, 0, nullptr};
+  }
+  if (x < -1) {
+    // ADS: this is an error condition and should be handled
+    // differently from the EOF above.
+    file.destroy();
+    free(line.s);
+    line = {0, 0, nullptr};
+  }
+  return file;
+}
+
+
+template<typename T>
+static inline uint32_t
+fill_output_buffer(const uint32_t offset, const MSite &s, T &buf) {
+  auto buf_end = buf.data() + buf.size();
+  auto res = to_chars(buf.data(), buf_end, s.pos - offset);
+  *res.ptr++ = '\t';
+  res = to_chars(res.ptr, buf_end, s.n_meth());
+  *res.ptr++ = '\t';
+  res = to_chars(res.ptr, buf_end, s.n_unmeth());
+  *res.ptr++ = '\n';
+  *res.ptr = '\0';
+  // if (res.ec != std::errc()) res.ptr = buf.data();
+  return std::distance(buf.data(), res.ptr);
+}
+
+
+int
+main_xcounts(int argc, const char **argv) {
+  try {
+    size_t n_threads = 1;
+
+    string outfile{"-"};
+    const string description =
+      "compress counts files by removing context information";
+
+    /****************** COMMAND LINE OPTIONS ********************/
+    OptionParser opt_parse(strip_path(argv[0]), description,
+                           "<counts-file> (\"-\" for standard input)", 1);
+    opt_parse.add_opt("output", 'o', "output file (default is standard out)",
+                      false, outfile);
+    opt_parse.add_opt("threads", 't', "threads for compression (use few)",
+                      false, n_threads);
+    std::vector<string> leftover_args;
+    opt_parse.parse(argc, argv, leftover_args);
+    if (argc == 1 || opt_parse.help_requested()) {
+      cerr << opt_parse.help_message() << endl
+           << opt_parse.about_message() << endl;
+      return EXIT_SUCCESS;
+    }
+    if (opt_parse.about_requested()) {
+      cerr << opt_parse.about_message() << endl;
+      return EXIT_SUCCESS;
+    }
+    if (opt_parse.option_missing()) {
+      cerr << opt_parse.option_missing_message() << endl;
+      return EXIT_SUCCESS;
+    }
+    if (leftover_args.size() != 1) {
+      cerr << opt_parse.help_message() << endl;
+      return EXIT_SUCCESS;
+    }
+    const string filename(leftover_args.front());
+    /****************** END COMMAND LINE OPTIONS *****************/
+
+    bamxx::bam_tpool tpool(n_threads);
+
+    bgzf_file in(filename, "r");
+    if (!in) throw runtime_error("could not open file: " + filename);
+
+    const auto outfile_mode = in.compression() ? "w" : "wu";
+
+    bgzf_file out(outfile, outfile_mode);
+    if (!out) throw runtime_error("error opening output file: " + outfile);
+
+    if (n_threads > 1) {
+      // ADS: something breaks when we use the thread for the input
+      tpool.set_io(in);
+      tpool.set_io(out);
+    }
+
+    // use the kstring_t type to more directly use the BGZF file
+    kstring_t line{0, 0, nullptr};
+    const int ret = ks_resize(&line, 1024);
+    if (ret) throw runtime_error("failed to acquire buffer");
+
+    vector<char> buf(1024);
+
+    // MAKE A HEADER IN THE COMPRESSED COUNTS FILE THAT IDENTIFIES THE
+    // GENOME WITH CHROMOSOME NAMES AND A HASH FOR EACH CHROMOSOME
+    // INCLUDING THE NUMBER OF SITES OF EACH TYPE.
+
+    uint32_t offset = 0;
+    string prev_chrom;
+    bool status_ok = true;
+    int64_t sz = 0;
+
+    MSite site;
+    while (status_ok && getline(in, line)) {
+      if (line.s[0] == '#') {
+        const auto header_line = string(line.s) + "\n";
+        sz = size(header_line);
+        status_ok = bgzf_write(out.f, header_line.data(), sz) == sz;
+        continue;
+      }
+      status_ok = site.initialize(line.s, line.s + line.l);
+      if (!status_ok) break;
+
+      if (site.chrom != prev_chrom) {
+        cerr << site.chrom << endl;
+        prev_chrom = site.chrom;
+        offset = 0;
+
+        site.chrom += '\n';
+        sz = size(site.chrom);
+        status_ok = bgzf_write(out.f, site.chrom.data(), sz) == sz;
+      }
+      if (site.n_reads > 0 || site.is_mutated()) {
+        sz = fill_output_buffer(offset, site, buf);
+        status_ok = bgzf_write(out.f, buf.data(), sz) == sz;
+        offset = site.pos;
+      }
+    }
+    if (!status_ok) {
+      cerr << "failed converting "
+           << filename << " to " << outfile << endl;
+      return EXIT_FAILURE;
+    }
+  }
+  catch (const std::runtime_error &e) {
+    cerr << e.what() << endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- methcounts.cpp: adding option to include a header in the counts output
- covered.cpp: minor fix in output when no args given
- symmetric-cpgs.cpp: added a function to print any header if it exists, which involves just printing leading lines that begin with # symbol
- bam_record_utils.hpp: added a function to get the target length from the header without specifying the internal header inside the bam_header object
- MSite.hpp and MSite.cpp: added a constructor from a char array with length. Also moved the logic of parsing strings to construct MSite into an initialize function which allows the same thing to be done without constructing a new object
- xcounts.cpp: adding this file to compress the counts files as small as possible
- dnmtools.cpp: adding the xcounts command
- Makefile.am: adding the xcounts.cpp file to the sources
- unxcounts.cpp: adding a tool to convert back from the xcounts format
- Makefile.am and dnmtools.cpp: adding the unxcounts command
- recovered.cpp: using getline then initalize the sites so that skipping the header is easier
- xcounts.cpp: removing output of chromosomes to stderr each time they change, not forcing a null char after the part of the buffer to be written, and making the buffer at most 128 bytes
- unxcounts.cpp: major changes for speed
