### PR TITLE
xcounts header prepend

### DIFF
--- a/src/common/counts_header.cpp
+++ b/src/common/counts_header.cpp
@@ -18,6 +18,8 @@
 
 #include "counts_header.hpp"
 
+#include <iostream>
+#include <fstream>
 #include <string>
 #include <vector>
 #include <cassert>
@@ -30,6 +32,7 @@
 #include <config.h>
 
 #include "bamxx.hpp"
+#include "dnmt_error.hpp"
 
 using std::vector;
 using std::string;
@@ -38,9 +41,9 @@ using std::to_string;
 using bamxx::bgzf_file;
 
 void
-write_counts_header_from_chom_sizes(const vector<string> &chrom_names,
-                                    const vector<uint64_t> &chrom_sizes,
-                                    bgzf_file &out) {
+write_counts_header_from_chrom_sizes(const vector<string> &chrom_names,
+                                     const vector<uint64_t> &chrom_sizes,
+                                     bgzf_file &out) {
   const auto version = "#DNMTOOLS " + string(VERSION) + "\n";
   out.write(version.c_str());
   for (auto i = 0u; i < size(chrom_sizes); ++i) {
@@ -49,6 +52,20 @@ write_counts_header_from_chom_sizes(const vector<string> &chrom_names,
     out.write(tmp.c_str());
   }
   out.write("#\n");
+}
+
+
+void
+write_counts_header_from_file(const string &header_file, bgzf_file &out) {
+  std::ifstream in(header_file);
+  if (!in.is_open()) {
+      throw dnmt_error("failed to open header file: " + header_file);
+  }
+  string line;
+  while(getline(in, line)) {
+    out.write(line + '\n');
+  }
+  in.close();
 }
 
 

--- a/src/common/counts_header.hpp
+++ b/src/common/counts_header.hpp
@@ -26,9 +26,13 @@
 #include "bamxx.hpp"
 
 void
-write_counts_header_from_chom_sizes(const std::vector<std::string> &chrom_names,
-                                    const std::vector<uint64_t> &chrom_sizes,
-                                    bamxx::bgzf_file &out);
+write_counts_header_from_chrom_sizes(const std::vector<std::string> &chrom_names,
+                                     const std::vector<uint64_t> &chrom_sizes,
+                                     bamxx::bgzf_file &out);
+
+void
+write_counts_header_from_file(const std::string &header_file, 
+                              bamxx::bgzf_file &out);
 
 // returns -1 on failure, 0 on success
 int

--- a/src/utils/xcounts.cpp
+++ b/src/utils/xcounts.cpp
@@ -85,6 +85,7 @@ main_xcounts(int argc, const char **argv) {
     bool require_coverage = false;
     size_t n_threads = 1;
     string genome_file;
+    string header_file;
 
     string outfile{"-"};
     const string description =
@@ -99,6 +100,8 @@ main_xcounts(int argc, const char **argv) {
                       false, genome_file);
     opt_parse.add_opt("reads", 'r', "ouput only sites with reads",
                       false, require_coverage);
+    opt_parse.add_opt("header", 'h', "use this file to generate header",
+                      false, header_file);
     opt_parse.add_opt("threads", 't', "threads for compression (use few)",
                       false, n_threads);
     std::vector<string> leftover_args;
@@ -151,8 +154,10 @@ main_xcounts(int argc, const char **argv) {
       tpool.set_io(out);
     }
 
-    if (!genome_file.empty())
-      write_counts_header_from_chom_sizes(chrom_names, chrom_sizes, out);
+    if (!header_file.empty())
+      write_counts_header_from_file(header_file, out);
+    else if (!genome_file.empty())
+      write_counts_header_from_chrom_sizes(chrom_names, chrom_sizes, out);
 
     // use the kstring_t type to more directly use the BGZF file
     kstring_t line{0, 0, nullptr};


### PR DESCRIPTION
- added option to specify header file for xcounts
- xcounts: ensuring a header is found either by the user providing a reference genome, the user directly providing a header, or the header already existing in the counts file
