### PR TITLE
unxcounts for sym

### DIFF
--- a/src/common/MSite.hpp
+++ b/src/common/MSite.hpp
@@ -24,27 +24,26 @@
 #include <unordered_map>
 
 struct MSite {
+  std::string chrom{};
+  size_t pos{};
+  char strand{};
+  std::string context{};
+  double meth{};
+  size_t n_reads{};
 
-  MSite() {}
-  MSite(const std::string &_chrom,
-        const size_t _pos,
-        const char _strand,
-        const std::string &_context,
-        const double _meth,
-        const size_t _n_reads) :
-    chrom(_chrom), pos(_pos), strand(_strand),
-    context(_context), meth(_meth), n_reads(_n_reads) {}
+  MSite() = default;
+  MSite(const std::string &chrom,
+        const size_t pos,
+        const char strand,
+        const std::string &context,
+        const double meth,
+        const size_t n_reads) :
+    chrom{chrom}, pos{pos}, strand{strand},
+    context{context}, meth{meth}, n_reads{n_reads} {}
   explicit MSite(const std::string &line);
   explicit MSite(const char *line, const int n);
 
   bool initialize(const char *c, const char *c_end);
-
-  std::string chrom;
-  size_t pos;
-  char strand;
-  std::string context;
-  double meth;
-  size_t n_reads;
 
   bool operator<(const MSite &other) const {
     int r = chrom.compare(other.chrom);

--- a/src/utils/unxcounts.cpp
+++ b/src/utils/unxcounts.cpp
@@ -16,47 +16,58 @@
  * General Public License for more details.
  */
 
-#include <string>
-#include <vector>
-#include <iostream>
-#include <stdexcept>
-#include <unordered_map>
-#include <unordered_set>
-#include <charconv>
 #include <bamxx.hpp>
 
+#include <charconv>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 // from smithlab_cpp
-#include "OptionParser.hpp"
-#include "smithlab_utils.hpp"
-#include "smithlab_os.hpp"
-#include "bsutils.hpp"
-#include "dnmt_error.hpp"
-#include "counts_header.hpp"
-
 #include "MSite.hpp"
+#include "OptionParser.hpp"
+#include "bsutils.hpp"
+#include "counts_header.hpp"
+#include "dnmt_error.hpp"
+#include "smithlab_os.hpp"
+#include "smithlab_utils.hpp"
 
-using std::string;
-using std::vector;
-using std::cout;
-using std::cerr;
-using std::endl;
-using std::unordered_map;
-using std::unordered_set;
-using std::pair;
-using std::numeric_limits;
-using std::runtime_error;
-using std::from_chars;
-using std::to_chars;
 using std::cbegin;
 using std::cend;
+using std::cerr;
 using std::copy;
 using std::copy_n;
+using std::cout;
+using std::endl;
+using std::from_chars;
+using std::numeric_limits;
+using std::pair;
+using std::runtime_error;
+using std::string;
+using std::to_chars;
 using std::to_string;
+using std::unordered_map;
+using std::unordered_set;
+using std::vector;
 
 using bamxx::bgzf_file;
 
 template<typename T> using num_lim = std::numeric_limits<T>;
 
+static void
+read_fasta_file_short_names_uppercase(const string &chroms_file,
+                                      vector<string> &names,
+                                      vector<string> &chroms) {
+  chroms.clear();
+  names.clear();
+  read_fasta_file_short_names(chroms_file, names, chroms);
+  for (auto &i : chroms)
+    transform(cbegin(i), cend(i), begin(i),
+              [](const char c) { return std::toupper(c); });
+}
 
 inline auto
 getline(bgzf_file &file, kstring_t &line) -> bgzf_file & {
@@ -73,10 +84,10 @@ getline(bgzf_file &file, kstring_t &line) -> bgzf_file & {
     file.destroy();
     free(line.s);
     line = {0, 0, nullptr};
+    throw runtime_error{"failed reading bgzf file"};
   }
   return file;
 }
-
 
 static void
 verify_chrom_orders(const bool verbose, const uint32_t n_threads,
@@ -88,11 +99,10 @@ verify_chrom_orders(const bool verbose, const uint32_t n_threads,
   if (!in) throw runtime_error("bad file: " + filename);
 
   // set the threads for the input file decompression
-  if (n_threads > 1 && in.is_bgzf())
-    tp.set_io(in);
+  if (n_threads > 1 && in.is_bgzf()) tp.set_io(in);
 
   unordered_set<int32_t> chroms_seen;
-  int32_t prev_idx = -1;
+  int32_t prev_id = -1;
 
   kstring_t line{0, 0, nullptr};
   const int ret = ks_resize(&line, 1024);
@@ -114,20 +124,20 @@ verify_chrom_orders(const bool verbose, const uint32_t n_threads,
       throw runtime_error("chroms out of order in: " + filename);
     chroms_seen.insert(idx);
 
-    if (idx < prev_idx)
+    if (idx < prev_id)
       throw runtime_error("inconsistent chromosome order at: " + chrom);
 
-    prev_idx = idx;
+    prev_id = idx;
   }
   if (verbose) cerr << "chrom orders are consistent" << endl;
 }
 
 static const char *tag_values[] = {
-  "CpG", // 0
-  "CHH", // 1
-  "CXG", // 2
-  "CCG", // 3
-  "N"    // 4
+  "CpG",  // 0
+  "CHH",  // 1
+  "CXG",  // 2
+  "CCG",  // 3
+  "N"     // 4
 };
 
 static const int tag_sizes[] = {3, 3, 3, 3, 1};
@@ -136,56 +146,56 @@ static const int tag_sizes[] = {3, 3, 3, 3, 1};
 // the triplet; I'm allowing that for consistency with the weird logic
 // from earlier versions.
 const uint32_t context_codes[] = {
-  /*CAA CHH*/   1,
-  /*CAC CHH*/   1,
-  /*CAG CXG*/   2,
-  /*CAT CHH*/   1,
-  /*CAN ---*/   1, //4,
-  /*CCA CHH*/   1,
-  /*CCC CHH*/   1,
-  /*CCG CCG*/   3,
-  /*CCT CHH*/   1,
-  /*CCN ---*/   1, //4,
-  /*CGA CpG*/   0,
-  /*CGC CpG*/   0,
-  /*CGG CpG*/   0,
-  /*CGT CpG*/   0,
-  /*CGN CpG*/   0,
-  /*CTA CHH*/   1,
-  /*CTC CHH*/   1,
-  /*CTG CXG*/   2,
-  /*CTT CHH*/   1,
-  /*CTN ---*/   1, //4,
-  /*CNA ---*/   1, //4,
-  /*CNC ---*/   1, //4,
-  /*CNG ---*/   2,
-  /*CNT ---*/   1, //4,
-  /*CNN ---*/   1  //4
+  /*CAA CHH*/ 1,
+  /*CAC CHH*/ 1,
+  /*CAG CXG*/ 2,
+  /*CAT CHH*/ 1,
+  /*CAN ---*/ 1,  // 4,
+  /*CCA CHH*/ 1,
+  /*CCC CHH*/ 1,
+  /*CCG CCG*/ 3,
+  /*CCT CHH*/ 1,
+  /*CCN ---*/ 1,  // 4,
+  /*CGA CpG*/ 0,
+  /*CGC CpG*/ 0,
+  /*CGG CpG*/ 0,
+  /*CGT CpG*/ 0,
+  /*CGN CpG*/ 0,
+  /*CTA CHH*/ 1,
+  /*CTC CHH*/ 1,
+  /*CTG CXG*/ 2,
+  /*CTT CHH*/ 1,
+  /*CTN ---*/ 1,  // 4,
+  /*CNA ---*/ 1,  // 4,
+  /*CNC ---*/ 1,  // 4,
+  /*CNG ---*/ 2,
+  /*CNT ---*/ 1,  // 4,
+  /*CNN ---*/ 1   // 4
 };
 
 static inline uint32_t
 get_tag_from_genome_c(const string &s, const size_t pos) {
-  const auto val = base2int(s[pos + 1])*5 + base2int(s[pos + 2]);
+  const auto val = base2int(s[pos + 1]) * 5 + base2int(s[pos + 2]);
   return context_codes[val];
 }
 
 static inline uint32_t
 get_tag_from_genome_g(const string &s, const size_t pos) {
-  const auto val = base2int(complement(s[pos - 1]))*5 +
-    base2int(complement(s[pos - 2]));
+  const auto val =
+    base2int(complement(s[pos - 1])) * 5 + base2int(complement(s[pos - 2]));
   return context_codes[val];
 }
 
 static bool
-write_missing_sites(const string &name, const string &chrom,
-                    const uint64_t start_pos, const uint64_t end_pos,
-                    vector<char> &buf, bgzf_file &out) {
+write_missing(const uint32_t name_size, const string &chrom,
+              const uint64_t start_pos, const uint64_t end_pos,
+              vector<char> &buf, bgzf_file &out) {
   static constexpr auto zeros = "\t0\t0\n";
   static constexpr auto pos_strand = "\t+\t";
   static constexpr auto neg_strand = "\t-\t";
   const auto buf_end = buf.data() + size(buf);
   // chrom name is already in the buffer so move past it
-  auto cursor = buf.data() + size(name) + 1;
+  auto cursor = buf.data() + name_size + 1;
   for (auto pos = start_pos; pos < end_pos; ++pos) {
     const char base = chrom[pos];
     if (is_cytosine(base) || is_guanine(base)) {
@@ -201,18 +211,42 @@ write_missing_sites(const string &name, const string &chrom,
       const auto sz = std::distance(buf.data(), ptr);
 #pragma GCC diagnostic push
 
-      if (bgzf_write(out.f, buf.data(), sz) != sz)
-        return false;
+      if (bgzf_write(out.f, buf.data(), sz) != sz) return false;
     }
   }
   return true;
 }
 
+static bool
+write_missing_cpg(const uint32_t &name_size, const string &chrom,
+                  const uint64_t start_pos, const uint64_t end_pos,
+                  vector<char> &buf, bgzf_file &out) {
+  static constexpr auto zeros = "\t0\t0\n";
+  static constexpr auto pos_strand = "\t+\t";
+  const auto buf_end = buf.data() + size(buf);
+  // chrom name is already in the buffer so move past it
+  auto cursor = buf.data() + name_size + 1;
+  for (auto pos = start_pos; pos < end_pos; ++pos) {
+    const char base = chrom[pos];
+    if (is_cytosine(base)) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic error "-Wstringop-overflow=0"
+      auto [ptr, ec] = to_chars(cursor, buf_end, pos);
+      ptr = copy_n(pos_strand, 3, ptr);
+      ptr = copy_n("CpG", 3, ptr);
+      ptr = copy_n(zeros, 5, ptr);
+      const auto sz = std::distance(buf.data(), ptr);
+#pragma GCC diagnostic push
+      if (bgzf_write(out.f, buf.data(), sz) != sz) return false;
+    }
+  }
+  return true;
+}
 
 static bool
-write_site(const string &name, const string &chrom,
-           const uint32_t pos, const uint32_t n_meth,
-           const uint32_t n_unmeth, vector<char> &buf, bgzf_file &out) {
+write_site(const uint32_t name_size, const string &chrom, const uint32_t pos,
+           const uint32_t n_meth, const uint32_t n_unmeth, vector<char> &buf,
+           bgzf_file &out) {
   static constexpr auto pos_strand = "\t+\t";
   static constexpr auto neg_strand = "\t-\t";
   static constexpr auto fmt = std::chars_format::general;
@@ -224,28 +258,28 @@ write_site(const string &name, const string &chrom,
   const uint32_t the_tag = is_c ? get_tag_from_genome_c(chrom, pos)
                                 : get_tag_from_genome_g(chrom, pos);
   const auto n_reads = n_meth + n_unmeth;
-  const auto meth = static_cast<double>(n_meth)/std::max(n_reads, 1u);
+  const auto meth = static_cast<double>(n_meth) / std::max(n_reads, 1u);
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic error "-Wstringop-overflow=0"
   // chrom name is already in the buffer so move past it
-  auto cursor = buf.data() + size(name) + 1;
+  auto cursor = buf.data() + name_size + 1;
   {
-  auto [ptr, ec] = to_chars(cursor, buf_end, pos);
-  cursor = ptr;
+    auto [ptr, ec] = to_chars(cursor, buf_end, pos);
+    cursor = ptr;
   }
   cursor = copy_n(is_c ? pos_strand : neg_strand, 3, cursor);
   cursor = copy_n(tag_values[the_tag], tag_sizes[the_tag], cursor);
   *cursor++ = '\t';
   {
-  // use default precision, 6, same as cout default
-  auto [ptr, ec] = to_chars(cursor, buf_end, meth, fmt, 6);
-  cursor = ptr;
+    // use default precision, 6, same as cout default
+    auto [ptr, ec] = to_chars(cursor, buf_end, meth, fmt, 6);
+    cursor = ptr;
   }
   *cursor++ = '\t';
   {
-  auto [ptr, ec] = to_chars(cursor, buf_end, n_reads);
-  cursor = ptr;
+    auto [ptr, ec] = to_chars(cursor, buf_end, n_reads);
+    cursor = ptr;
   }
   *cursor++ = '\n';
 #pragma GCC diagnostic push
@@ -254,76 +288,104 @@ write_site(const string &name, const string &chrom,
   return bgzf_write(out.f, buf.data(), sz) == sz;
 }
 
-
 typedef vector<string>::const_iterator chrom_itr_t;
-
 
 static chrom_itr_t
 get_chrom(const unordered_map<string, chrom_itr_t> &chrom_lookup,
           const string &chrom_name) {
-  const auto chrom_idx = chrom_lookup.find(chrom_name);
-  if (chrom_idx == cend(chrom_lookup))
+  const auto chr_id = chrom_lookup.find(chrom_name);
+  if (chr_id == cend(chrom_lookup))
     throw dnmt_error("chromosome not found: " + chrom_name);
-  return chrom_idx->second;
+  return chr_id->second;
 }
-
 
 static int32_t
-get_chrom_idx(const unordered_map<string, int32_t> &name_to_idx,
+get_chrom_id(const unordered_map<string, int32_t> &name_to_id,
               const string &chrom_name) {
-  const auto chrom_idx = name_to_idx.find(chrom_name);
-  if (chrom_idx == cend(name_to_idx))
+  const auto chr_id = name_to_id.find(chrom_name);
+  if (chr_id == cend(name_to_id))
     throw dnmt_error("chromosome not found: " + chrom_name);
-  return chrom_idx->second;
+  return chr_id->second;
 }
-
 
 static bool
 verify_chrom(const string &header_line,
-             const unordered_map<string, int32_t> &name_to_idx,
-             vector<uint64_t> &chrom_sizes) {
-  if (is_counts_header_version_line(header_line))
-    return true;
+             const unordered_map<string, int32_t> &name_to_id,
+             const vector<uint64_t> &chrom_sizes) {
+  if (is_counts_header_version_line(header_line)) return true;
   std::istringstream iss(header_line.substr(1));
   string name;
   uint64_t chrom_size = 0;
-  if (!(iss >> name >> chrom_size))
-    return false;
+  if (!(iss >> name >> chrom_size)) return false;
 
-  const auto idx = name_to_idx.find(name);
-  if (idx == cend(name_to_idx)) return false;
+  const auto idx = name_to_id.find(name);
+  if (idx == cend(name_to_id)) return false;
 
   return chrom_size == chrom_sizes[idx->second];
 }
 
+static void
+get_lookups(const vector<string> &names, const vector<string> &chroms,
+            unordered_map<string, chrom_itr_t> &chrom_lookup,
+            unordered_map<string, int32_t> &name_to_id,
+            vector<uint64_t> &chrom_sizes) {
+  chrom_lookup.clear();
+  name_to_id.clear();
+  chrom_sizes = vector<uint64_t>(size(chroms), 0);
+  for (size_t i = 0; i < size(chroms); ++i) {
+    chrom_lookup[names[i]] = cbegin(chroms) + i;
+    name_to_id[names[i]] = i;
+    chrom_sizes[i] = size(chroms[i]);
+  }
+}
+
+static void
+process_header_line(const unordered_map<string, int32_t> &name_to_id,
+                    const vector<uint64_t> &chrom_sizes, const kstring_t &line,
+                    bgzf_file &out) {
+  string hdr_line{line.s};
+  if (size(hdr_line) > 1 && !verify_chrom(hdr_line, name_to_id, chrom_sizes))
+    throw runtime_error{"failed to verify header for: " + hdr_line};
+  if (!write_counts_header_line(hdr_line, out))
+    throw runtime_error{"failed to write header line: " + hdr_line};
+}
+
+
+// write all sites for chroms in the given range
+static void
+write_all_sites(const bool verbose,
+                const uint32_t prev_chr_id,
+                const uint32_t chr_id,
+                const vector<string> &names,
+                const vector<string> &chroms,
+                vector<char> &buf, bgzf_file &out) {
+  for (auto i = prev_chr_id + 1; i < chr_id; ++i) {
+    if (verbose)
+      cerr << "processing: " << names[i] << " (missing)" << endl;
+    auto res = copy(cbegin(names[i]), cend(names[i]), buf.data());
+    *res = '\t';
+    write_missing(size(names[i]), chroms[i], 0u, size(chroms[i]), buf, out);
+  }
+}
 
 static void
 process_sites(const bool verbose, const bool add_missing_chroms,
-              const bool require_covered,
-              const bool compress_output, const size_t n_threads,
-              const string &infile, const string &outfile,
-              const string &chroms_file) {
-
+              const bool require_covered, const bool compress_output,
+              const size_t n_threads, const string &infile,
+              const string &outfile, const string &chroms_file) {
   // first get the chromosome names and sequences from the FASTA file
   vector<string> chroms, names;
-  read_fasta_file_short_names(chroms_file, names, chroms);
-  for (auto &i : chroms)
-    transform(cbegin(i), cend(i), begin(i),
-              [](const char c) { return std::toupper(c); });
+  read_fasta_file_short_names_uppercase(chroms_file, names, chroms);
   if (verbose)
     cerr << "[n chroms in reference: " << chroms.size() << "]" << endl;
 
   unordered_map<string, chrom_itr_t> chrom_lookup;
-  unordered_map<string, int32_t> name_to_idx;
+  unordered_map<string, int32_t> name_to_id;
   vector<uint64_t> chrom_sizes(size(chroms), 0);
-  for (size_t i = 0; i < size(chroms); ++i) {
-    chrom_lookup[names[i]] = cbegin(chroms) + i;
-    name_to_idx[names[i]] = i;
-    chrom_sizes[i] = size(chroms[i]);
-  }
+  get_lookups(names, chroms, chrom_lookup, name_to_id, chrom_sizes);
 
   if (add_missing_chroms)
-    verify_chrom_orders(verbose, n_threads, infile, name_to_idx);
+    verify_chrom_orders(verbose, n_threads, infile, name_to_id);
 
   bamxx::bam_tpool tp(n_threads);
 
@@ -340,52 +402,44 @@ process_sites(const bool verbose, const bool add_missing_chroms,
     tp.set_io(out);
   }
 
-  vector<char> buf(1024, '\0');
+  static constexpr uint32_t output_buffer_size = 1024;
+  vector<char> buf(output_buffer_size, '\0');
 
   kstring_t line{0, 0, nullptr};
-  const int ret = ks_resize(&line, 1024);
+  const int ret = ks_resize(&line, output_buffer_size);
   if (ret) throw runtime_error("failed to acquire buffer");
 
   string chrom_name;
-  int32_t prev_chrom_idx = -1;
+  uint32_t nm_sz{};
+  int32_t prev_chr_id = -1;
   uint64_t pos = num_lim<uint64_t>::max();
 
   // ADS: this is probably a poor strategy since we already would know
   // the index of the chrom sequence in the vector.
-  chrom_itr_t chrom_itr;
+  chrom_itr_t ch_itr;
 
   while (getline(in, line)) {
     if (is_counts_header_line(line.s)) {
-      string header_line{line.s};
-      if (size(header_line) > 1 && !verify_chrom(header_line, name_to_idx, chrom_sizes))
-        throw runtime_error("failed to verify header for: " + header_line);
-      if (!write_counts_header_line(header_line, out))
-        throw runtime_error("failed to write header line: " + header_line);
-      continue;
+      process_header_line(name_to_id, chrom_sizes, line, out);
+      continue;  // ADS: early loop exit
     }
 
-    if (!std::isdigit(line.s[0])) {
+    if (!std::isdigit(line.s[0])) {  // check if we have a chrom line
 
       if (!require_covered && pos != num_lim<uint64_t>::max())
-        write_missing_sites(chrom_name, *chrom_itr, pos + 1, size(*chrom_itr), buf, out);
+        write_missing(nm_sz, *ch_itr, pos + 1, size(*ch_itr), buf, out);
 
       chrom_name = string{line.s};
-      const int32_t chrom_idx = get_chrom_idx(name_to_idx, chrom_name);
+      nm_sz = size(chrom_name);
+      const int32_t chr_id = get_chrom_id(name_to_id, chrom_name);
 
       if (add_missing_chroms)
-        for (auto i = prev_chrom_idx + 1; i < chrom_idx; ++i) {
-          auto res = copy(cbegin(names[i]), cend(names[i]), buf.data());
-          *res = '\t';
-          if (verbose)
-            cerr << "processing: " << names[i] << " (missing)" << endl;
-          write_missing_sites(names[i], chroms[i], 0u, size(chroms[i]), buf, out);
-        }
+        write_all_sites(verbose, prev_chr_id, chr_id, names, chroms, buf, out);
 
-      chrom_itr = get_chrom(chrom_lookup, chrom_name);
+      ch_itr = get_chrom(chrom_lookup, chrom_name);
       pos = 0;
-      prev_chrom_idx = chrom_idx;
-      if (verbose)
-        cerr << "processing: " << chrom_name << endl;
+      prev_chr_id = chr_id;
+      if (verbose) cerr << "processing: " << chrom_name << endl;
 
       auto res = copy(cbegin(chrom_name), cend(chrom_name), buf.data());
       *res = '\t';
@@ -399,36 +453,141 @@ process_sites(const bool verbose, const bool add_missing_chroms,
 
       const auto curr_pos = pos + pos_step;
       if (!require_covered && pos + 1 < curr_pos)
-        write_missing_sites(chrom_name, *chrom_itr, pos + 1, curr_pos, buf, out);
+        write_missing(nm_sz, *ch_itr, pos + 1, curr_pos, buf, out);
 
-      write_site(chrom_name, *chrom_itr, curr_pos, n_meth, n_unmeth, buf, out);
+      write_site(nm_sz, *ch_itr, curr_pos, n_meth, n_unmeth, buf, out);
       pos = curr_pos;
     }
   }
   if (!require_covered)
-    write_missing_sites(chrom_name, *chrom_itr, pos + 1, size(*chrom_itr), buf, out);
+    write_missing(nm_sz, *ch_itr, pos + 1, size(*ch_itr), buf, out);
+  if (add_missing_chroms)
+    write_all_sites(verbose, prev_chr_id, size(chroms), names, chroms, buf,
+                    out);
+}
 
-  if (add_missing_chroms) {
-    const int32_t chrom_idx = size(chroms);
-    for (auto i = prev_chrom_idx + 1; i < chrom_idx; ++i) {
-      auto res = copy(cbegin(names[i]), cend(names[i]), buf.data());
-      *res = '\t';
-      if (verbose)
-        cerr << "processing: " << names[i] << " (missing)" << endl;
-      write_missing_sites(names[i], chroms[i], 0u, size(chroms[i]), buf, out);
-    }
+// write all cpg sites for chroms in the given range
+static void
+write_all_cpgs(const bool verbose,
+               const uint32_t prev_chr_id,
+               const uint32_t chr_id,
+               const vector<string> &names,
+               const vector<string> &chroms,
+               vector<char> &buf, bgzf_file &out) {
+  for (auto i = prev_chr_id + 1; i < chr_id; ++i) {
+    if (verbose)
+      cerr << "processing: " << names[i] << " (missing)" << endl;
+    auto res = copy(cbegin(names[i]), cend(names[i]), buf.data());
+    *res = '\t';
+    write_missing_cpg(size(names[i]), chroms[i], 0u, size(chroms[i]), buf, out);
   }
 }
 
+static void
+process_cpg_sites(const bool verbose, const bool add_missing_chroms,
+                  const bool require_covered, const bool compress_output,
+                  const size_t n_threads, const string &infile,
+                  const string &outfile, const string &chroms_file) {
+  // first get the chromosome names and sequences from the FASTA file
+  vector<string> chroms, names;
+  read_fasta_file_short_names_uppercase(chroms_file, names, chroms);
+  if (verbose)
+    cerr << "[n chroms in reference: " << chroms.size() << "]" << endl;
+
+  unordered_map<string, chrom_itr_t> chrom_lookup;
+  unordered_map<string, int32_t> name_to_id;
+  vector<uint64_t> chrom_sizes(size(chroms), 0);
+  get_lookups(names, chroms, chrom_lookup, name_to_id, chrom_sizes);
+
+  if (add_missing_chroms)
+    verify_chrom_orders(verbose, n_threads, infile, name_to_id);
+
+  bamxx::bam_tpool tp(n_threads);
+
+  bamxx::bgzf_file in(infile, "r");
+  if (!in) throw dnmt_error("failed to open input file");
+
+  const string output_mode = compress_output ? "w" : "wu";
+  bgzf_file out(outfile, output_mode);
+  if (!out) throw dnmt_error("error opening output file: " + outfile);
+
+  // set the threads for the input file decompression
+  if (n_threads > 1) {
+    if (in.is_bgzf()) tp.set_io(in);
+    tp.set_io(out);
+  }
+
+  static constexpr uint32_t output_buffer_size = 1024;
+  vector<char> buf(output_buffer_size, '\0');
+
+  kstring_t line{0, 0, nullptr};
+  const int ret = ks_resize(&line, output_buffer_size);
+  if (ret) throw runtime_error("failed to acquire buffer");
+
+  string chrom_name;
+  uint32_t nm_sz{};
+  int32_t prev_chr_id = -1;
+  uint64_t pos = num_lim<uint64_t>::max();
+
+  // ADS: this is probably a poor strategy since we already would know
+  // the index of the chrom sequence in the vector.
+  chrom_itr_t ch_itr;
+
+  while (getline(in, line)) {
+    if (is_counts_header_line(line.s)) {
+      process_header_line(name_to_id, chrom_sizes, line, out);
+      continue;  // ADS: early loop exit
+    }
+
+    if (!std::isdigit(line.s[0])) {  // check if we have a chrom line
+
+      if (!require_covered && pos != num_lim<uint64_t>::max())
+        write_missing_cpg(nm_sz, *ch_itr, pos + 1, size(*ch_itr), buf, out);
+
+      chrom_name = string{line.s};
+      nm_sz = size(chrom_name);
+      const int32_t chr_id = get_chrom_id(name_to_id, chrom_name);
+
+      if (add_missing_chroms)
+        write_all_cpgs(verbose, prev_chr_id, chr_id, names, chroms, buf, out);
+
+      ch_itr = get_chrom(chrom_lookup, chrom_name);
+      pos = 0;
+      prev_chr_id = chr_id;
+      if (verbose) cerr << "processing: " << chrom_name << endl;
+
+      auto res = copy(cbegin(chrom_name), cend(chrom_name), buf.data());
+      *res = '\t';
+    }
+    else {
+      uint32_t pos_step = 0, n_meth = 0, n_unmeth = 0;
+      const auto end_line = line.s + line.l;
+      auto res = from_chars(line.s, end_line, pos_step);
+      res = from_chars(res.ptr + 1, end_line, n_meth);
+      res = from_chars(res.ptr + 1, end_line, n_unmeth);
+
+      const auto curr_pos = pos + pos_step;
+      if (!require_covered && pos + 1 < curr_pos)
+        write_missing_cpg(nm_sz, *ch_itr, pos + 1, curr_pos, buf, out);
+
+      write_site(nm_sz, *ch_itr, curr_pos, n_meth, n_unmeth, buf, out);
+      pos = curr_pos;
+    }
+  }
+  if (!require_covered)
+    write_missing_cpg(nm_sz, *ch_itr, pos + 1, size(*ch_itr), buf, out);
+  if (add_missing_chroms)
+    write_all_cpgs(verbose, prev_chr_id, size(chroms), names, chroms, buf, out);
+}
 
 int
 main_unxcounts(int argc, const char **argv) {
   try {
-
     bool verbose = false;
     bool add_missing_chroms = false;
     bool require_covered = false;
     bool compress_output = false;
+    bool assume_cpg_only = false;
     size_t n_threads = 1;
 
     string outfile;
@@ -437,15 +596,17 @@ main_unxcounts(int argc, const char **argv) {
       "convert compressed counts format back to full counts";
 
     /****************** COMMAND LINE OPTIONS ********************/
-    OptionParser opt_parse(strip_path(argv[0]), description,
-                           "<xcounts-file>");
+    OptionParser opt_parse(strip_path(argv[0]), description, "<xcounts-file>");
     opt_parse.add_opt("output", 'o', "output file (required)", true, outfile);
-    opt_parse.add_opt("missing", 'm', "add missing chroms", false, add_missing_chroms);
+    opt_parse.add_opt("missing", 'm', "add missing chroms", false,
+                      add_missing_chroms);
+    opt_parse.add_opt("cpg", '\0', "assume symmetric CpG input and output",
+                      false, assume_cpg_only);
     opt_parse.add_opt("reads", 'r', "report only sites with reads", false,
                       require_covered);
     opt_parse.add_opt("threads", 't', "number of threads", false, n_threads);
     opt_parse.add_opt("chrom", 'c', "reference genome file (FASTA format)",
-                      true , chroms_file);
+                      true, chroms_file);
     opt_parse.add_opt("zip", 'z', "output gzip format", false, compress_output);
     opt_parse.add_opt("verbose", 'v', "print more run info", false, verbose);
     std::vector<string> leftover_args;
@@ -479,8 +640,13 @@ main_unxcounts(int argc, const char **argv) {
       return EXIT_FAILURE;
     }
 
-    process_sites(verbose, add_missing_chroms, require_covered, compress_output,
-                  n_threads, filename, outfile, chroms_file);
+    if (assume_cpg_only)
+      process_cpg_sites(verbose, add_missing_chroms, require_covered,
+                        compress_output, n_threads, filename, outfile,
+                        chroms_file);
+    else
+      process_sites(verbose, add_missing_chroms, require_covered,
+                    compress_output, n_threads, filename, outfile, chroms_file);
   }
   catch (const std::runtime_error &e) {
     cerr << e.what() << endl;


### PR DESCRIPTION
- src/common/MSite.hpp: reorganizing the class definition and constructor that takes all instance vars in order
- src/utils/unxcounts.cpp: adding functionality for counts files that only include symmetric cpgs sites
