### PR TITLE
One-based variable-step bigWig in kmersites

### DIFF
--- a/src/utils/kmersites.cpp
+++ b/src/utils/kmersites.cpp
@@ -110,7 +110,7 @@ kmersites(const int argc, const char **argv) -> int {
     string kmer = "CG";
     string outfile;
     // int n_threads = 1;
-    int offset = 0;
+    int offset = 1;
 
     /****************** COMMAND LINE OPTIONS ********************/
     OptionParser opt_parse(fs::path(string(*argv)).filename(),


### PR DESCRIPTION
Since kmersites is intended to create tracks for the ucsc genome browser, the offset argument should default to 1 since we usually want to change the 0-based chromosomal positions to 1-based for the standard in wigToBigWig.