### PR TITLE
Bugfix in min reads for fraction in merge command

### DIFF
--- a/src/utils/merge-methcounts.cpp
+++ b/src/utils/merge-methcounts.cpp
@@ -183,7 +183,7 @@ write_line_for_tabular(const bool write_fractional,
   if (write_fractional) {
     for (size_t i = 0; i < n_files; ++i) {
       const size_t r = sites[i].n_reads;
-      if (to_print[i] && r > min_reads)
+      if (to_print[i] && r >= min_reads)
         out << '\t' << sites[i].meth;
       else
         out << '\t' << "NA";


### PR DESCRIPTION
This bug checked that the read count for a site was greater than instead of greater than or equal to the min reads specified by the user for allowing integer counts to converted to a fractional value between 0 and 1