### PR TITLE
Allowing unmapped reads in counts, bsrate, format and uniq

### DIFF
--- a/src/analysis/bsrate.cpp
+++ b/src/analysis/bsrate.cpp
@@ -580,12 +580,14 @@ main_bsrate(int argc, const char **argv) {
     unordered_set<int32_t> chroms_seen;
 
     while (hts.read(hdr, aln)) {
+      const int32_t the_tid = get_tid(aln);
+      if (the_tid == -1)
+        continue;
+
       if (reads_are_a_rich) flip_conversion(aln);
 
       // get the correct chrom if it has changed
-      if (get_tid(aln) != current_tid) {
-        const int32_t the_tid = get_tid(aln);
-
+      if (the_tid != current_tid) {
         // make sure all reads from same chrom are contiguous in the file
         if (chroms_seen.find(the_tid) != end(chroms_seen))
           throw runtime_error("chroms out of order in mapped reads file");

--- a/src/utils/format-reads.cpp
+++ b/src/utils/format-reads.cpp
@@ -341,6 +341,10 @@ format(const string &cmd, const size_t n_threads, const string &inputfile,
     swap(aln, prev_aln);  // start with prev_aln being first read
 
     while (hts.read(hdr, aln)) {
+      // ADS: skip reads that have no tid -- they are not mapped
+      if (get_tid(aln) == -1)
+        continue;
+
       standardize_format(input_format, aln);
       if (same_name(prev_aln, aln, suff_len)) {
         // below: essentially check for dovetail


### PR DESCRIPTION
This is done by simply skipping the reads for which tid is -1 and completely ignoring them