### PR TITLE
Adding flag to format command for reads in SAM orientation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,6 @@ install installdirs: SUBDIRS := $(filter-out src/smithlab_cpp src/abismal, $(SUB
 AM_CPPFLAGS = -I $(top_srcdir)/src/common -I $(top_srcdir)/src/smithlab_cpp -I $(top_srcdir)/src/bamxx
 
 AM_CXXFLAGS = -Wall -Wextra -Wpedantic -Wno-unknown-attributes
-CXXFLAGS += -O3 -DNDEBUG # default has optimization on
 
 EXTRA_DIST = \
              README.md \

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,13 @@ AM_INIT_AUTOMAKE([subdir-objects foreign])
 AC_CONFIG_MACRO_DIR([m4])
 AC_LANG(C++)
 AC_PROG_CXX
+
+# Set CXXFLAGS only if the user hasn't set them
+AS_IF([test "x$CXXFLAGS_set" != "xset"], [
+  CXXFLAGS="-O3 -DNDEBUG"
+])
+AC_MSG_NOTICE([CXXFLAGS is $CXXFLAGS])
+
 AX_CXX_COMPILE_STDCXX_17([noext], [mandatory])
 AC_PROG_RANLIB
 

--- a/data/md5sum.txt
+++ b/data/md5sum.txt
@@ -18,7 +18,7 @@ d41d8cd98f00b204e9800998ecf8427e  tests/two_epialleles.amr
 001b9d966f62fa439b24cf2198cc3de5  tests/reads.counts.sym
 2b8a0406015458be51b8b1c9e58b3602  tests/tRex1_promoters.roi.bed
 9bdb361091d1c0626df30be8ba2c408c  tests/reads.sam
-00ca55777ac7d9cd87823bdf293a3d7f  tests/reads.fmt.sam
 98a7f3ae4bb296c32b6751e326977c51  tests/reads.fmt.srt.uniq.sam
 fa21ade51680ef2752768f02e32eb2e8  tests/reads.xcounts
 14e8f72fde8d0f669b17da6cf4a908b6  tests/reads.unxcounts
+dd6657967ff946ad4f194f1a29051f94  tests/reads.fmt.sam

--- a/data/md5sum.txt
+++ b/data/md5sum.txt
@@ -18,7 +18,7 @@ d41d8cd98f00b204e9800998ecf8427e  tests/two_epialleles.amr
 001b9d966f62fa439b24cf2198cc3de5  tests/reads.counts.sym
 2b8a0406015458be51b8b1c9e58b3602  tests/tRex1_promoters.roi.bed
 9bdb361091d1c0626df30be8ba2c408c  tests/reads.sam
-98a7f3ae4bb296c32b6751e326977c51  tests/reads.fmt.srt.uniq.sam
 fa21ade51680ef2752768f02e32eb2e8  tests/reads.xcounts
 14e8f72fde8d0f669b17da6cf4a908b6  tests/reads.unxcounts
 dd6657967ff946ad4f194f1a29051f94  tests/reads.fmt.sam
+5c8375a9f70163f5c89608147fe21693  tests/reads.fmt.srt.uniq.sam

--- a/src/common/bam_record_utils.hpp
+++ b/src/common/bam_record_utils.hpp
@@ -292,4 +292,7 @@ rlen_from_cigar(const bamxx::bam_rec &aln) {
   return bam_cigar2rlen(get_n_cigar(aln), bam_get_cigar(aln));
 }
 
+void
+revcomp_qseq(bamxx::bam_rec &aln);
+
 #endif

--- a/src/common/dnmtools_utils.cpp
+++ b/src/common/dnmtools_utils.cpp
@@ -15,19 +15,20 @@
 
 #include "dnmtools_utils.hpp"
 
-#include <string>
-#include <sstream>
 #include <algorithm>
 #include <iterator>
+#include <sstream>
+#include <string>
 
-using std::string;
 using std::copy;
-using std::ostringstream;
 using std::ostream_iterator;
+using std::ostringstream;
+using std::string;
 
 auto
-get_command_line(const int argc, const char **const argv) -> string {
-  if (argc == 0) return string();
+get_command_line(const int argc, char *argv[]) -> std::string {
+  if (argc == 0)
+    return std::string{};
   std::ostringstream cmd;
   cmd << '"';
   copy(argv, argv + (argc - 1), ostream_iterator<const char *>(cmd, " "));

--- a/src/common/dnmtools_utils.hpp
+++ b/src/common/dnmtools_utils.hpp
@@ -19,6 +19,6 @@
 #include <string>
 
 auto
-get_command_line(const int argc, const char **const argv) -> std::string;
+get_command_line(const int argc, char *argv[]) -> std::string;
 
 #endif


### PR DESCRIPTION
SAM orientation reverse complements reads that map to the negative strand. Abismal can now output in strict SAM format if a flag is given. This PR adds the functionality in the format command to accept the strict SAM format.