### PR TITLE
radmeth sample consistency between design and data matrix

### DIFF
--- a/src/radmeth/radmeth.cpp
+++ b/src/radmeth/radmeth.cpp
@@ -361,6 +361,19 @@ that the design matrix and the proportion table are correctly formatted.
     progress(table_file);
 }
 
+static void
+ensure_sample_order(const std::string &table_filename, Regression &alt_model,
+                    Regression &null_model) {
+  std::ifstream table_file(table_filename);
+  if (!table_file)
+    throw std::runtime_error("could not open file: " + table_filename);
+  std::string header;
+  std::getline(table_file, header);
+  const auto sample_names = get_sample_names_from_header(header);
+  alt_model.order_samples(sample_names);
+  null_model.order_samples(sample_names);
+}
+
 int
 main_radmeth(int argc, char *argv[]) {
   try {
@@ -446,16 +459,7 @@ main_radmeth(int argc, char *argv[]) {
     if (verbose)
       std::cerr << "Null model:\n" << null_model.design << '\n';
 
-    {
-      std::ifstream table_file(table_filename);
-      if (!table_file)
-        throw std::runtime_error("could not open file: " + table_filename);
-      std::string header;
-      std::getline(table_file, header);
-      const auto sample_names = get_sample_names_from_header(header);
-      alt_model.order_samples(sample_names);
-      null_model.order_samples(sample_names);
-    }
+    ensure_sample_order(table_filename, alt_model, null_model);
 
     // clang-format off
     if (verbose)

--- a/src/radmeth/radmeth_model.cpp
+++ b/src/radmeth/radmeth_model.cpp
@@ -170,37 +170,40 @@ Design::drop_factor(const std::size_t factor_idx) {
 
 void
 Design::order_samples(const std::vector<std::string> &ordered_names) {
-  const auto lookup = [&] {
-    std::unordered_map<std::string, std::uint32_t> tmp;
-    std::uint32_t idx{};
-    for (const auto &name : ordered_names)
-      tmp.emplace(name, idx++);
-    return tmp;
+  // Build lookup: sample name -> original index
+  const auto sample_to_index = [&] {
+    std::unordered_map<std::string, std::uint32_t> sample_to_index;
+    std::uint32_t index = 0;
+    for (const auto &sample : sample_names)
+      sample_to_index.emplace(sample, index++);
+    return sample_to_index;
   }();
 
-  auto tmp_sample_names = sample_names;
-  auto tmp_matrix = matrix;
-  auto tmp_group_id = group_id;
+  std::vector<std::string> ord_sample_names;
+  std::vector<std::vector<std::uint8_t>> ord_matrix;
+  std::vector<std::uint32_t> ord_group_id;
   // factor names should not change
   // groups should not change
   // tmatrix will be changed after matrix
 
   const auto n_names = std::size(ordered_names);
-  for (auto i = 0u; i < std::size(tmp_sample_names); ++i) {
-    const auto itr = lookup.find(tmp_sample_names[i]);
-    if (itr == std::cend(lookup))
-      throw std::runtime_error("sample not found: " + tmp_sample_names[i]);
-    const std::uint32_t idx = itr->second;
-    sample_names[idx] = tmp_sample_names[i];
-    matrix[idx] = tmp_matrix[i];
-    group_id[idx] = tmp_group_id[i];
-  }
+  ord_sample_names.reserve(n_names);
+  ord_matrix.reserve(n_names);
+  ord_group_id.reserve(n_names);
 
-  // make sure no extra entries for samples in the design but that don't have
-  // data in the table
-  sample_names.resize(n_names);
-  matrix.resize(n_names);
-  group_id.resize(n_names);
+  for (const auto &name : ordered_names) {
+    const auto it = sample_to_index.find(name);
+    if (it == std::cend(sample_to_index))
+      throw std::runtime_error("Sample not found: " + name);
+
+    const auto original_index = it->second;
+    ord_sample_names.push_back(sample_names[original_index]);
+    ord_matrix.push_back(matrix[original_index]);
+    ord_group_id.push_back(group_id[original_index]);
+  }
+  sample_names = std::move(ord_sample_names);
+  matrix = std::move(ord_matrix);
+  group_id = std::move(ord_group_id);
 
   // update tmatrix using matrix
   transpose(matrix, tmatrix);

--- a/src/radmeth/radmeth_model.hpp
+++ b/src/radmeth/radmeth_model.hpp
@@ -34,10 +34,10 @@ struct cumul_counts {
 struct Design {
   std::vector<std::string> factor_names;
   std::vector<std::string> sample_names;
-  std::vector<std::vector<std::uint8_t>> matrix;
-  std::vector<std::vector<std::uint8_t>> tmatrix;
-  std::vector<std::vector<std::uint8_t>> groups;
-  std::vector<std::uint32_t> group_id;
+  std::vector<std::vector<std::uint8_t>> matrix;   // samples=rows, factors=cols
+  std::vector<std::vector<std::uint8_t>> tmatrix;  // factors=rows, samples=cols
+  std::vector<std::vector<std::uint8_t>> groups;   // combs of fact levels
+  std::vector<std::uint32_t> group_id;             // assign group to sample
 
   [[nodiscard]] std::size_t
   n_factors() const {
@@ -56,6 +56,9 @@ struct Design {
 
   [[nodiscard]] Design
   drop_factor(const std::size_t factor_idx);
+
+  void
+  order_samples(const std::vector<std::string> &ordered_names);
 };
 
 std::istream &
@@ -120,6 +123,11 @@ struct Regression {
   [[nodiscard]] std::size_t
   n_samples() const {
     return design.n_samples();
+  }
+
+  void
+  order_samples(const std::vector<std::string> &ordered_names) {
+    design.order_samples(ordered_names);
   }
 };
 


### PR DESCRIPTION
This will help allow radmeth to run even if the order of sample names differs between the design matrix and the data matrix, and even if the design matrix has extra samples