### PR TITLE
Updates including fix for roi on counts-nano output and move to strict SAM as assumed in format command 

### DIFF
--- a/data/md5sum.txt
+++ b/data/md5sum.txt
@@ -7,8 +7,6 @@ e73facd597c3b903cbfe29afa9f58371  tests/reads.counts
 0f72560aa101e85679783a1ecaf80615  tests/reads.epiread
 9dbd476424d48a8d0f043dfc00af0d23  tests/reads.fmt.srt.sam
 4085cc74b003a918b4a4743fca7922a4  tests/reads.hmr
-5c6fbbc6e565f23afa4f597f2483acb0  tests/reads.levels
-a389e4ee1687895517b0b0d26e9338ee  tests/reads.mstats
 d8856f9731af76b8a4ab3cc7d667cdb2  tests/reads.ustats
 bcbf01be810cbf4051292813eb6b9225  tests/tRex1.idx
 ec6a686617cad31e9f7a37a3d378e6ed  tests/two_epialleles.states
@@ -17,8 +15,10 @@ d947fe3d61ef7b1564558a69608f0e64  tests/methylome.pmd
 d41d8cd98f00b204e9800998ecf8427e  tests/two_epialleles.amr
 001b9d966f62fa439b24cf2198cc3de5  tests/reads.counts.sym
 2b8a0406015458be51b8b1c9e58b3602  tests/tRex1_promoters.roi.bed
-9bdb361091d1c0626df30be8ba2c408c  tests/reads.sam
 33640b24cb64ad3179f364af5a887f95  tests/reads.fmt.sam
 b5a63997c57dcde5c3a6635f7beb2cce  tests/reads.fmt.srt.uniq.sam
 3ac2b51545740bafd1a548ba7f73e739  tests/reads.xcounts
 054fe804a32063c80862fbee30f74579  tests/reads.unxcounts
+830157684f1ddbf1f1c37d354188dc2b  tests/reads.sam
+8dbcdabecb6cfe6aebb73c94c605f696  tests/reads.mstats
+490723e9af084c8f957f5a265cf02994  tests/reads.levels

--- a/src/analysis/hmr.cpp
+++ b/src/analysis/hmr.cpp
@@ -14,6 +14,17 @@
  * GNU General Public License for more details.
  */
 
+#include "MSite.hpp"
+#include "TwoStateHMM.hpp"
+#include "counts_header.hpp"
+
+#include "GenomicRegion.hpp"
+#include "OptionParser.hpp"
+#include "smithlab_os.hpp"
+#include "smithlab_utils.hpp"
+
+#include <bamxx.hpp>
+
 #include <cmath>
 #include <cstdint>  // for [u]int[0-9]+_t
 #include <fstream>
@@ -24,57 +35,29 @@
 #include <string>
 #include <unordered_set>
 
-#include <bamxx.hpp>
-
-#include "GenomicRegion.hpp"
-#include "OptionParser.hpp"
-#include "smithlab_os.hpp"
-#include "smithlab_utils.hpp"
-
-#include "MSite.hpp"
-#include "TwoStateHMM.hpp"
-#include "counts_header.hpp"
-
-using std::accumulate;
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::make_pair;
-using std::max;
-using std::min;
-using std::numeric_limits;
-using std::pair;
-using std::reduce;
-using std::runtime_error;
-using std::string;
-using std::to_string;
-using std::unordered_set;
-using std::vector;
-
-using bamxx::bgzf_file;
-
 struct hmr_summary {
-  hmr_summary(const vector<GenomicRegion> &hmrs) {
+  hmr_summary(const std::vector<GenomicRegion> &hmrs) {
     hmr_count = hmrs.size();
-    hmr_total_size = accumulate(cbegin(hmrs), cend(hmrs), 0ul,
-                                [](const uint64_t t, const GenomicRegion &p) {
-                                  return t + p.get_width();
-                                });
+    hmr_total_size =
+      std::accumulate(std::cbegin(hmrs), std::cend(hmrs), 0ul,
+                      [](const std::uint64_t t, const GenomicRegion &p) {
+                        return t + p.get_width();
+                      });
     hmr_mean_size = static_cast<double>(hmr_total_size) /
-                    std::max(hmr_count, static_cast<uint64_t>(1));
+                    std::max(hmr_count, static_cast<std::uint64_t>(1));
   }
   // hmr_count is the number of identified HMRs.
-  uint64_t hmr_count{};
+  std::uint64_t hmr_count{};
   // total_hmr_size is the sum of the sizes of the identified HMRs
-  uint64_t hmr_total_size{};
+  std::uint64_t hmr_total_size{};
   // mean_hmr_size is the mean size of the identified HMRs
   double hmr_mean_size{};
 
-  string
+  std::string
   tostring() {
     std::ostringstream oss;
-    oss << "hmr_count: " << hmr_count << endl
-        << "hmr_total_size: " << hmr_total_size << endl
+    oss << "hmr_count: " << hmr_count << '\n'
+        << "hmr_total_size: " << hmr_total_size << '\n'
         << "hmr_mean_size: " << std::fixed << std::setprecision(2)
         << hmr_mean_size;
 
@@ -87,36 +70,37 @@ as_gen_rgn(const MSite &s) {
   return GenomicRegion(s.chrom, s.pos, s.pos + 1);
 }
 
-static string
-format_cpg_meth_tag(const pair<double, double> &m) {
-  return "CpG:" + to_string(static_cast<size_t>(m.first)) + ":" +
-         to_string(static_cast<size_t>(m.second));
+static std::string
+format_cpg_meth_tag(const std::pair<double, double> &m) {
+  return "CpG:" + std::to_string(static_cast<std::size_t>(m.first)) + ":" +
+         std::to_string(static_cast<std::size_t>(m.second));
 }
 
 static double
-get_stepup_cutoff(vector<double> scores, const double cutoff) {
+get_stepup_cutoff(std::vector<double> scores, const double cutoff) {
   if (cutoff <= 0)
-    return numeric_limits<double>::max();
+    return std::numeric_limits<double>::max();
   else if (cutoff > 1)
-    return numeric_limits<double>::min();
+    return std::numeric_limits<double>::min();
 
-  const size_t n = scores.size();
-  std::sort(begin(scores), end(scores));
-  size_t i = 1;
+  const std::size_t n = scores.size();
+  std::sort(begin(scores), std::end(scores));
+  std::size_t i = 1;
   while (i < n && scores[i - 1] < (cutoff * i) / n)
     ++i;
   return scores[i - 1];
 }
 
 static void
-get_domain_scores(const vector<bool> &state_ids,
-                  const vector<pair<double, double>> &meth,
-                  const vector<size_t> &reset_points, vector<double> &scores) {
+get_domain_scores(const std::vector<bool> &state_ids,
+                  const std::vector<std::pair<double, double>> &meth,
+                  const std::vector<std::size_t> &reset_points,
+                  std::vector<double> &scores) {
 
-  size_t reset_idx = 1;
+  std::size_t reset_idx = 1;
   bool in_domain = false;
   double score = 0;
-  for (size_t i = 0; i < state_ids.size(); ++i) {
+  for (std::size_t i = 0; i < state_ids.size(); ++i) {
     if (reset_points[reset_idx] == i) {
       if (in_domain) {
         in_domain = false;
@@ -141,12 +125,14 @@ get_domain_scores(const vector<bool> &state_ids,
 }
 
 static void
-build_domains(const vector<MSite> &cpgs, const vector<size_t> &reset_points,
-              const vector<bool> &state_ids, vector<GenomicRegion> &domains) {
+build_domains(const std::vector<MSite> &cpgs,
+              const std::vector<std::size_t> &reset_points,
+              const std::vector<bool> &state_ids,
+              std::vector<GenomicRegion> &domains) {
 
-  size_t n_cpgs = 0, reset_idx = 1, prev_end = 0;
+  std::size_t n_cpgs = 0, reset_idx = 1, prev_end = 0;
   bool in_domain = false;
-  for (size_t i = 0; i < state_ids.size(); ++i) {
+  for (std::size_t i = 0; i < state_ids.size(); ++i) {
     if (reset_points[reset_idx] == i) {
       if (in_domain) {
         in_domain = false;
@@ -160,7 +146,7 @@ build_domains(const vector<MSite> &cpgs, const vector<size_t> &reset_points,
       if (!in_domain) {
         in_domain = true;
         domains.push_back(as_gen_rgn(cpgs[i]));
-        domains.back().set_name("HYPO" + to_string(domains.size()));
+        domains.back().set_name("HYPO" + std::to_string(domains.size()));
       }
       ++n_cpgs;
     }
@@ -180,38 +166,39 @@ build_domains(const vector<MSite> &cpgs, const vector<size_t> &reset_points,
 
 template <class T, class U>
 static void
-separate_regions(const bool verbose, const size_t desert_size,
-                 vector<MSite> &cpgs, vector<T> &meth, vector<U> &reads,
-                 vector<size_t> &reset_points) {
+separate_regions(const bool verbose, const std::size_t desert_size,
+                 std::vector<MSite> &cpgs, std::vector<T> &meth,
+                 std::vector<U> &reads,
+                 std::vector<std::size_t> &reset_points) {
   if (verbose)
-    cerr << "[separating by cpg desert]" << endl;
+    std::cerr << "[separating by cpg desert]" << '\n';
   // eliminate the zero-read cpgs
-  size_t j = 0;
-  for (size_t i = 0; i < cpgs.size(); ++i)
+  std::size_t j = 0;
+  for (std::size_t i = 0; i < cpgs.size(); ++i)
     if (reads[i] > 0) {
       cpgs[j] = cpgs[i];
       meth[j] = meth[i];
       reads[j] = reads[i];
       ++j;
     }
-  cpgs.erase(begin(cpgs) + j, end(cpgs));
-  meth.erase(begin(meth) + j, end(meth));
-  reads.erase(begin(reads) + j, end(reads));
+  cpgs.erase(std::begin(cpgs) + j, std::end(cpgs));
+  meth.erase(std::begin(meth) + j, std::end(meth));
+  reads.erase(std::begin(reads) + j, std::end(reads));
 
   double total_bases = 0;
   double bases_in_deserts = 0;
   // segregate cpgs
-  size_t prev_pos = 0;
-  for (size_t i = 0; i < cpgs.size(); ++i) {
-    const size_t dist = (i > 0 && cpgs[i].chrom == cpgs[i - 1].chrom)
-                          ? cpgs[i].pos - prev_pos
-                          : numeric_limits<size_t>::max();
+  std::size_t prev_pos = 0;
+  for (std::size_t i = 0; i < cpgs.size(); ++i) {
+    const std::size_t dist = (i > 0 && cpgs[i].chrom == cpgs[i - 1].chrom)
+                               ? cpgs[i].pos - prev_pos
+                               : std::numeric_limits<std::size_t>::max();
     if (dist > desert_size) {
       reset_points.push_back(i);
-      if (dist < numeric_limits<size_t>::max())
+      if (dist < std::numeric_limits<std::size_t>::max())
         bases_in_deserts += dist;
     }
-    if (dist < numeric_limits<size_t>::max())
+    if (dist < std::numeric_limits<std::size_t>::max())
       total_bases += dist;
 
     prev_pos = cpgs[i].pos;
@@ -219,10 +206,10 @@ separate_regions(const bool verbose, const size_t desert_size,
   reset_points.push_back(cpgs.size());
 
   if (verbose)
-    cerr << "[cpgs retained: " << cpgs.size() << "]" << endl
-         << "[deserts removed: " << reset_points.size() - 2 << "]" << endl
-         << "[genome fraction covered: "
-         << 1.0 - (bases_in_deserts / total_bases) << "]" << endl;
+    std::cerr << "[cpgs retained: " << cpgs.size() << "]" << '\n'
+              << "[deserts removed: " << reset_points.size() - 2 << "]" << '\n'
+              << "[genome fraction covered: "
+              << 1.0 - (bases_in_deserts / total_bases) << "]" << '\n';
 }
 
 /* function to "fold" the methylation profile so that the middle
@@ -230,9 +217,9 @@ separate_regions(const bool verbose, const size_t desert_size,
  * methylation become high. this method actually seems to work.
  */
 static void
-make_partial_meth(const vector<uint32_t> &reads,
-                  vector<pair<double, double>> &meth) {
-  for (size_t i = 0; i < reads.size(); ++i) {
+make_partial_meth(const std::vector<std::uint32_t> &reads,
+                  std::vector<std::pair<double, double>> &meth) {
+  for (std::size_t i = 0; i < reads.size(); ++i) {
     double m = meth[i].first / reads[i];
     m = (m <= 0.5) ? (1.0 - 2 * m) : (1.0 - 2 * (1.0 - m));
     meth[i].first = reads[i] * m;
@@ -241,58 +228,60 @@ make_partial_meth(const vector<uint32_t> &reads,
 }
 
 static void
-shuffle_cpgs(const size_t rng_seed, const TwoStateHMM &hmm,
-             vector<pair<double, double>> meth, vector<size_t> reset_points,
-             const double p_fb, const double p_bf, const double fg_alpha,
-             const double fg_beta, const double bg_alpha, const double bg_beta,
-             vector<double> &domain_scores) {
+shuffle_cpgs(const std::size_t rng_seed, const TwoStateHMM &hmm,
+             std::vector<std::pair<double, double>> meth,
+             std::vector<std::size_t> reset_points, const double p_fb,
+             const double p_bf, const double fg_alpha, const double fg_beta,
+             const double bg_alpha, const double bg_beta,
+             std::vector<double> &domain_scores) {
 
   auto eng = std::default_random_engine(rng_seed);
-  std::shuffle(begin(meth), end(meth), eng);
+  std::shuffle(std::begin(meth), std::end(meth), eng);
 
-  vector<bool> state_ids;
-  vector<double> scores;
+  std::vector<bool> state_ids;
+  std::vector<double> scores;
   hmm.PosteriorDecoding(meth, reset_points, p_fb, p_bf, fg_alpha, fg_beta,
                         bg_alpha, bg_beta, state_ids, scores);
   get_domain_scores(state_ids, meth, reset_points, domain_scores);
-  sort(begin(domain_scores), end(domain_scores));
+  sort(std::begin(domain_scores), std::end(domain_scores));
 }
 
 static void
-assign_p_values(const vector<double> &random_scores,
-                const vector<double> &observed_scores,
-                vector<double> &p_values) {
+assign_p_values(const std::vector<double> &random_scores,
+                const std::vector<double> &observed_scores,
+                std::vector<double> &p_values) {
   const double n_randoms = random_scores.empty() ? 1 : random_scores.size();
-  for (size_t i = 0; i < observed_scores.size(); ++i)
-    p_values.push_back((end(random_scores) - upper_bound(begin(random_scores),
-                                                         end(random_scores),
-                                                         observed_scores[i])) /
-                       n_randoms);
+  for (std::size_t i = 0; i < observed_scores.size(); ++i)
+    p_values.push_back(
+      (std::end(random_scores) - upper_bound(std::begin(random_scores),
+                                             std::end(random_scores),
+                                             observed_scores[i])) /
+      n_randoms);
 }
 
 static void
-read_params_file(const bool verbose, const string &params_file,
+read_params_file(const bool verbose, const std::string &params_file,
                  double &fg_alpha, double &fg_beta, double &bg_alpha,
                  double &bg_beta, double &p_fb, double &p_bf,
                  double &domain_score_cutoff) {
-  string jnk;
+  std::string jnk;
   std::ifstream in(params_file);
   if (!in)
-    throw runtime_error("failed to parse params file: " + params_file);
+    throw std::runtime_error("failed to parse params file: " + params_file);
   in >> jnk >> fg_alpha >> jnk >> fg_beta >> jnk >> bg_alpha >> jnk >>
     bg_beta >> jnk >> p_fb >> jnk >> p_bf >> jnk >> domain_score_cutoff;
   if (verbose)
-    cerr << "FG_ALPHA\t" << fg_alpha << endl
-         << "FG_BETA\t" << fg_beta << endl
-         << "BG_ALPHA\t" << bg_alpha << endl
-         << "BG_BETA\t" << bg_beta << endl
-         << "F_B\t" << p_fb << endl
-         << "B_F\t" << p_bf << endl
-         << "DOMAIN_SCORE_CUTOFF\t" << domain_score_cutoff << endl;
+    std::cerr << "FG_ALPHA\t" << fg_alpha << '\n'
+              << "FG_BETA\t" << fg_beta << '\n'
+              << "BG_ALPHA\t" << bg_alpha << '\n'
+              << "BG_BETA\t" << bg_beta << '\n'
+              << "F_B\t" << p_fb << '\n'
+              << "B_F\t" << p_bf << '\n'
+              << "DOMAIN_SCORE_CUTOFF\t" << domain_score_cutoff << '\n';
 }
 
 static void
-write_params_file(const string &outfile, const double fg_alpha,
+write_params_file(const std::string &outfile, const double fg_alpha,
                   const double fg_beta, const double bg_alpha,
                   const double bg_beta, const double p_fb, const double p_bf,
                   const double domain_score_cutoff) {
@@ -303,13 +292,13 @@ write_params_file(const string &outfile, const double fg_alpha,
   std::ostream out(outfile.empty() ? std::cout.rdbuf() : of.rdbuf());
 
   out.precision(30);
-  out << "FG_ALPHA\t" << fg_alpha << endl
-      << "FG_BETA\t" << fg_beta << endl
-      << "BG_ALPHA\t" << bg_alpha << endl
-      << "BG_BETA\t" << bg_beta << endl
-      << "F_B\t" << p_fb << endl
-      << "B_F\t" << p_bf << endl
-      << "DOMAIN_SCORE_CUTOFF\t" << domain_score_cutoff << endl;
+  out << "FG_ALPHA\t" << fg_alpha << '\n'
+      << "FG_BETA\t" << fg_beta << '\n'
+      << "BG_ALPHA\t" << bg_alpha << '\n'
+      << "BG_BETA\t" << bg_beta << '\n'
+      << "F_B\t" << p_fb << '\n'
+      << "B_F\t" << p_bf << '\n'
+      << "DOMAIN_SCORE_CUTOFF\t" << domain_score_cutoff << '\n';
 }
 
 [[nodiscard]]
@@ -325,12 +314,13 @@ get_n_unmeth(const MSite &s) {
 }
 
 static void
-load_cpgs(const string &cpgs_file, vector<MSite> &cpgs,
-          vector<pair<double, double>> &meth, vector<uint32_t> &reads) {
+load_cpgs(const std::string &cpgs_file, std::vector<MSite> &cpgs,
+          std::vector<std::pair<double, double>> &meth,
+          std::vector<std::uint32_t> &reads) {
 
-  bgzf_file in(cpgs_file, "r");
+  bamxx::bgzf_file in(cpgs_file, "r");
   if (!in)
-    throw runtime_error("failed opening file: " + cpgs_file);
+    throw std::runtime_error("failed opening file: " + cpgs_file);
 
   if (get_has_counts_header(cpgs_file))
     skip_counts_header(in);
@@ -338,10 +328,12 @@ load_cpgs(const string &cpgs_file, vector<MSite> &cpgs,
   MSite prev_site, the_site;
   while (read_site(in, the_site)) {
     if (!the_site.is_cpg() || distance(prev_site, the_site) < 2)
-      throw runtime_error("error: input is not symmetric-CpGs: " + cpgs_file);
+      throw std::runtime_error("error: input is not symmetric-CpGs: " +
+                               cpgs_file);
     cpgs.push_back(the_site);
     reads.push_back(the_site.n_reads);
-    meth.push_back(make_pair(get_n_meth(the_site), get_n_unmeth(the_site)));
+    meth.push_back(
+      std::make_pair(get_n_meth(the_site), get_n_unmeth(the_site)));
     prev_site = the_site;
   }
 }
@@ -349,7 +341,7 @@ load_cpgs(const string &cpgs_file, vector<MSite> &cpgs,
 template <typename InputIterator, typename T = double>
 static auto
 get_mean(InputIterator first, InputIterator last) -> T {
-  return accumulate(first, last, static_cast<T>(0)) /
+  return std::accumulate(first, last, static_cast<T>(0)) /
          std::distance(first, last);
 }
 
@@ -361,15 +353,15 @@ check_sorted_within_chroms(T first, const T last) {
   if (first == last || first + 1 == last)
     return;
 
-  unordered_set<string> chroms_seen;
-  string cur_chrom = "";
+  std::unordered_set<std::string> chroms_seen;
+  std::string cur_chrom = "";
 
   for (auto fast = first + 1; fast != last; ++fast, ++first) {
     if (fast->chrom != cur_chrom) {
-      if (chroms_seen.find(fast->chrom) != end(chroms_seen)) {
-        throw runtime_error("input not grouped by chromosomes. "
-                            "Error in the following line:\n" +
-                            fast->tostring());
+      if (chroms_seen.find(fast->chrom) != std::end(chroms_seen)) {
+        throw std::runtime_error("input not grouped by chromosomes. "
+                                 "Error in the following line:\n" +
+                                 fast->tostring());
       }
       cur_chrom = fast->chrom;
       chroms_seen.insert(cur_chrom);
@@ -377,9 +369,9 @@ check_sorted_within_chroms(T first, const T last) {
     }
     else {  // first and fast are in the same chrom
       if (first->pos >= fast->pos) {
-        throw runtime_error("input file not sorted properly. "
-                            "Error in the following lines:\n" +
-                            first->tostring() + "\n" + fast->tostring());
+        throw std::runtime_error("input file not sorted properly. "
+                                 "Error in the following lines:\n" +
+                                 first->tostring() + "\n" + fast->tostring());
       }
     }
   }
@@ -392,13 +384,13 @@ main_hmr(int argc, char *argv[]) {
 
     constexpr double min_coverage = 1.0;
 
-    string outfile;
-    string hypo_post_outfile;
-    string meth_post_outfile;
+    std::string outfile;
+    std::string hypo_post_outfile;
+    std::string meth_post_outfile;
 
-    size_t desert_size = 1000;
-    size_t max_iterations = 10;
-    size_t rng_seed = 408;
+    std::size_t desert_size = 1000;
+    std::size_t max_iterations = 10;
+    std::size_t rng_seed = 408;
 
     // run mode flags
     bool verbose = false;
@@ -408,12 +400,12 @@ main_hmr(int argc, char *argv[]) {
     // corrections for small values
     const double tolerance = 1e-10;
 
-    string summary_file;
+    std::string summary_file;
 
-    string params_in_file;
-    string params_out_file;
+    std::string params_in_file;
+    std::string params_out_file;
 
-    const string description =
+    const std::string description =
       "Identify HMRs in methylomes. Methylation must be provided in the \
       methcounts format (chrom, position, strand, context,              \
       methylation, reads). See the methcounts documentation for         \
@@ -455,71 +447,71 @@ main_hmr(int argc, char *argv[]) {
                       "input has extra fields (used for nanopore)", false,
                       allow_extra_fields);
     opt_parse.set_show_defaults();
-    vector<string> leftover_args;
+    std::vector<std::string> leftover_args;
     opt_parse.parse(argc, argv, leftover_args);
     if (argc == 1 || opt_parse.help_requested()) {
-      cerr << opt_parse.help_message() << endl
-           << opt_parse.about_message() << endl;
+      std::cerr << opt_parse.help_message() << '\n'
+                << opt_parse.about_message() << '\n';
       return EXIT_SUCCESS;
     }
     if (opt_parse.about_requested()) {
-      cerr << opt_parse.about_message() << endl;
+      std::cerr << opt_parse.about_message() << '\n';
       return EXIT_SUCCESS;
     }
     if (opt_parse.option_missing()) {
-      cerr << opt_parse.option_missing_message() << endl;
+      std::cerr << opt_parse.option_missing_message() << '\n';
       return EXIT_SUCCESS;
     }
     if (leftover_args.empty()) {
-      cerr << opt_parse.help_message() << endl;
+      std::cerr << opt_parse.help_message() << '\n';
       return EXIT_SUCCESS;
     }
-    const string cpgs_file = leftover_args.front();
+    const std::string cpgs_file = leftover_args.front();
     /****************** END COMMAND LINE OPTIONS *****************/
 
     MSite::no_extra_fields = (allow_extra_fields == false);
 
     if (!is_msite_file(cpgs_file))
-      throw runtime_error("malformed counts file: " + cpgs_file);
+      throw std::runtime_error("malformed counts file: " + cpgs_file);
 
     // separate the regions by chrom and by desert
-    vector<MSite> cpgs;
-    vector<pair<double, double>> meth;
-    vector<uint32_t> reads;
+    std::vector<MSite> cpgs;
+    std::vector<std::pair<double, double>> meth;
+    std::vector<std::uint32_t> reads;
     if (verbose)
-      cerr << "[reading methylation levels]" << endl;
+      std::cerr << "[reading methylation levels]\n";
     load_cpgs(cpgs_file, cpgs, meth, reads);
 
     if (verbose)
-      cerr << "[checking if input is properly formatted]" << endl;
-    check_sorted_within_chroms(begin(cpgs), end(cpgs));
+      std::cerr << "[checking if input is properly formatted]\n";
+    check_sorted_within_chroms(std::begin(cpgs), std::end(cpgs));
     if (PARTIAL_METH)
       make_partial_meth(reads, meth);
 
-    const auto mean_coverage = get_mean(cbegin(reads), cend(reads));
+    const auto mean_coverage = get_mean(std::cbegin(reads), std::cend(reads));
 
     if (verbose)
-      cerr << "[total_cpgs=" << size(cpgs) << "]" << '\n'
-           << "[mean_coverage=" << mean_coverage << "]" << endl;
+      std::cerr << "[total_cpgs=" << size(cpgs) << "]" << '\n'
+                << "[mean_coverage=" << mean_coverage << "]" << '\n';
 
     // check for sufficient data
     if (mean_coverage < static_cast<double>(min_coverage)) {
       if (verbose)
-        cerr << "error: insufficient data"
-             << " mean_coverage=" << mean_coverage
-             << " min_coverage=" << min_coverage << endl;
+        std::cerr << "error: insufficient data"
+                  << " mean_coverage=" << mean_coverage
+                  << " min_coverage=" << min_coverage << '\n';
       if (!summary_file.empty()) {
         std::ofstream summary_out(summary_file);
         if (!summary_out)
-          throw runtime_error("failed to open: " + summary_file);
-        summary_out << hmr_summary({}).tostring() << endl;
+          throw std::runtime_error("failed to open: " + summary_file);
+        summary_out << hmr_summary({}).tostring() << '\n';
       }
       return EXIT_SUCCESS;
     }
 
     // separate the regions by chrom and by desert, and eliminate
     // those isolated CpGs
-    vector<size_t> reset_points;
+    std::vector<std::size_t> reset_points;
     separate_regions(verbose, desert_size, cpgs, meth, reads, reset_points);
 
     const TwoStateHMM hmm(tolerance, max_iterations, verbose);
@@ -537,7 +529,7 @@ main_hmr(int argc, char *argv[]) {
       max_iterations = 0;
     }
     else {
-      const double n_reads = get_mean(begin(reads), end(reads));
+      const double n_reads = get_mean(std::cbegin(reads), std::cend(reads));
       fg_alpha = 0.33 * n_reads;
       fg_beta = 0.67 * n_reads;
       bg_alpha = 0.67 * n_reads;
@@ -548,22 +540,22 @@ main_hmr(int argc, char *argv[]) {
       hmm.BaumWelchTraining(meth, reset_points, p_fb, p_bf, fg_alpha, fg_beta,
                             bg_alpha, bg_beta);
     // DECODE THE DOMAINS
-    vector<bool> state_ids;
-    vector<double> posteriors;
+    std::vector<bool> state_ids;
+    std::vector<double> posteriors;
     hmm.PosteriorDecoding(meth, reset_points, p_fb, p_bf, fg_alpha, fg_beta,
                           bg_alpha, bg_beta, state_ids, posteriors);
 
-    vector<double> domain_scores;
+    std::vector<double> domain_scores;
     get_domain_scores(state_ids, meth, reset_points, domain_scores);
 
-    vector<double> random_scores;
+    std::vector<double> random_scores;
     shuffle_cpgs(rng_seed, hmm, meth, reset_points, p_fb, p_bf, fg_alpha,
                  fg_beta, bg_alpha, bg_beta, random_scores);
 
-    vector<double> p_values;
+    std::vector<double> p_values;
     assign_p_values(random_scores, domain_scores, p_values);
 
-    if (domain_score_cutoff == numeric_limits<double>::max() &&
+    if (domain_score_cutoff == std::numeric_limits<double>::max() &&
         !domain_scores.empty())
       domain_score_cutoff = get_stepup_cutoff(p_values, 0.01);
 
@@ -572,7 +564,7 @@ main_hmr(int argc, char *argv[]) {
       write_params_file(params_out_file, fg_alpha, fg_beta, bg_alpha, bg_beta,
                         p_fb, p_bf, domain_score_cutoff);
 
-    vector<GenomicRegion> domains;
+    std::vector<GenomicRegion> domains;
     if (!domain_scores.empty())
       build_domains(cpgs, reset_points, state_ids, domains);
 
@@ -581,11 +573,12 @@ main_hmr(int argc, char *argv[]) {
       of.open(outfile);
     std::ostream out(outfile.empty() ? std::cout.rdbuf() : of.rdbuf());
 
-    size_t good_hmr_count = 0;
+    std::size_t good_hmr_count = 0;
     for (auto i = 0u; i < size(domains); ++i)
       if (p_values[i] < domain_score_cutoff) {
         domains[good_hmr_count] = domains[i];
-        domains[good_hmr_count].set_name("HYPO" + to_string(good_hmr_count));
+        domains[good_hmr_count].set_name("HYPO" +
+                                         std::to_string(good_hmr_count));
         ++good_hmr_count;
       }
     domains.resize(good_hmr_count);
@@ -595,9 +588,9 @@ main_hmr(int argc, char *argv[]) {
 
     if (!hypo_post_outfile.empty()) {
       if (verbose)
-        cerr << "[writing=" << hypo_post_outfile << "]" << endl;
+        std::cerr << "[writing=" << hypo_post_outfile << "]\n";
       std::ofstream out(hypo_post_outfile);
-      for (size_t i = 0; i < cpgs.size(); ++i) {
+      for (std::size_t i = 0; i < cpgs.size(); ++i) {
         GenomicRegion cpg(as_gen_rgn(cpgs[i]));
         cpg.set_name(format_cpg_meth_tag(meth[i]));
         cpg.set_score(posteriors[i]);
@@ -608,8 +601,8 @@ main_hmr(int argc, char *argv[]) {
     if (!meth_post_outfile.empty()) {
       std::ofstream out(meth_post_outfile);
       if (verbose)
-        cerr << "[writing=" << meth_post_outfile << "]" << endl;
-      for (size_t i = 0; i < cpgs.size(); ++i) {
+        std::cerr << "[writing=" << meth_post_outfile << "]\n";
+      for (std::size_t i = 0; i < cpgs.size(); ++i) {
         GenomicRegion cpg(as_gen_rgn(cpgs[i]));
         cpg.set_name(format_cpg_meth_tag(meth[i]));
         cpg.set_score(1.0 - posteriors[i]);
@@ -619,12 +612,12 @@ main_hmr(int argc, char *argv[]) {
     if (!summary_file.empty()) {
       std::ofstream summary_out(summary_file);
       if (!summary_out)
-        throw runtime_error("failed to open: " + summary_file);
-      summary_out << hmr_summary(domains).tostring() << endl;
+        throw std::runtime_error("failed to open: " + summary_file);
+      summary_out << hmr_summary(domains).tostring() << '\n';
     }
   }
-  catch (runtime_error &e) {
-    cerr << e.what() << endl;
+  catch (std::exception &e) {
+    std::cerr << e.what() << '\n';
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/src/common/LevelsCounter.cpp
+++ b/src/common/LevelsCounter.cpp
@@ -62,8 +62,7 @@ LevelsCounter::tostring() const {
 
   // derived values
   oss << indent << "coverage: " << coverage() << '\n'
-      << indent << "sites_covered_fraction: " << sites_covered_fraction()
-      << '\n'
+      << indent << "sites_covered_frac: " << sites_covered_frac() << '\n'
       << indent << "mean_depth: " << mean_depth() << '\n'
       << indent << "mean_depth_covered: " << mean_depth_covered() << '\n'
       << indent << "mean_meth: " << (good ? std::to_string(mean_meth()) : "NA")

--- a/src/common/LevelsCounter.cpp
+++ b/src/common/LevelsCounter.cpp
@@ -1,16 +1,16 @@
-/* Copyright (C) 2018-2022 Andrew D. Smith
+/* Copyright (C) 2018-2025 Andrew D. Smith
  *
  * Authors: Andrew D. Smith
  *
- * This is free software: you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
  *
  * This software is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
  */
 
 #include "LevelsCounter.hpp"
@@ -19,10 +19,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-
-using std::runtime_error;
-using std::string;
-using std::to_string;
 
 void
 LevelsCounter::update(const MSite &s) {
@@ -135,8 +131,8 @@ operator<<(std::ostream &out, const LevelsCounter &cs) {
 static void
 check_label(const std::string &observed, const std::string expected) {
   if (observed != expected)
-    throw runtime_error("bad levels format [" + observed + "," + expected +
-                        "]");
+    throw std::runtime_error("bad levels format [" + observed + "," + expected +
+                             "]");
 }
 
 std::istream &

--- a/src/common/LevelsCounter.cpp
+++ b/src/common/LevelsCounter.cpp
@@ -16,13 +16,13 @@
 #include "LevelsCounter.hpp"
 #include "bsutils.hpp"
 
-#include <string>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
+using std::runtime_error;
 using std::string;
 using std::to_string;
-using std::runtime_error;
 
 void
 LevelsCounter::update(const MSite &s) {
@@ -43,9 +43,9 @@ LevelsCounter::update(const MSite &s) {
   ++total_sites;
 }
 
-string
+std::string
 LevelsCounter::tostring() const {
-  static const string indent = string(2, ' ');
+  static const std::string indent = std::string(2, ' ');
   const bool good = (sites_covered != 0);
   std::ostringstream oss;
   // directly counted values
@@ -62,22 +62,20 @@ LevelsCounter::tostring() const {
 
   // derived values
   oss << indent << "coverage: " << coverage() << '\n'
-      << indent << "sites_covered_fraction: "
-      << static_cast<double>(sites_covered)/total_sites << '\n'
-      << indent << "mean_depth: "
-      << static_cast<double>(coverage())/total_sites << '\n'
-      << indent << "mean_depth_covered: "
-      << static_cast<double>(coverage())/sites_covered << '\n'
-      << indent << "mean_meth: "
-      << (good ? to_string(mean_meth()) : "NA")  << '\n'
+      << indent << "sites_covered_fraction: " << sites_covered_fraction()
+      << '\n'
+      << indent << "mean_depth: " << mean_depth() << '\n'
+      << indent << "mean_depth_covered: " << mean_depth_covered() << '\n'
+      << indent << "mean_meth: " << (good ? std::to_string(mean_meth()) : "NA")
+      << '\n'
       << indent << "mean_meth_weighted: "
-      << (good ? to_string(mean_meth_weighted()) : "NA") << '\n'
+      << (good ? std::to_string(mean_meth_weighted()) : "NA") << '\n'
       << indent << "fractional_meth: "
-      << (good ? to_string(fractional_meth()) : "NA");
+      << (good ? std::to_string(fractional_meth()) : "NA");
   return oss.str();
 }
 
-string
+std::string
 LevelsCounter::format_row() const {
   const bool good = (sites_covered > 0);
   std::ostringstream oss;
@@ -104,7 +102,7 @@ LevelsCounter::format_row() const {
   return oss.str();
 }
 
-string
+std::string
 LevelsCounter::format_header() {
   std::ostringstream oss;
   // directly counted values
@@ -136,42 +134,43 @@ operator<<(std::ostream &out, const LevelsCounter &cs) {
 }
 
 static void
-check_label(const string &observed, const string expected) {
+check_label(const std::string &observed, const std::string expected) {
   if (observed != expected)
-    throw runtime_error("bad levels format [" + observed + "," + expected + "]");
+    throw runtime_error("bad levels format [" + observed + "," + expected +
+                        "]");
 }
 
 std::istream &
 operator>>(std::istream &in, LevelsCounter &cs) {
-  in >> cs.context; // get the context
+  in >> cs.context;  // get the context
   cs.context = cs.context.substr(0, cs.context.find_first_of(":"));
 
-  string label;
-  in >> label >> cs.total_sites; // the total sites
+  std::string label;
+  in >> label >> cs.total_sites;  // the total sites
   check_label(label, "total_sites:");
 
-  in >> label >> cs.sites_covered; // the sites covered
+  in >> label >> cs.sites_covered;  // the sites covered
   check_label(label, "sites_covered:");
 
-  in >> label >> cs.total_c; // the total c
+  in >> label >> cs.total_c;  // the total c
   check_label(label, "total_c:");
 
-  in >> label >> cs.total_t; // the total t
+  in >> label >> cs.total_t;  // the total t
   check_label(label, "total_t:");
 
-  in >> label >> cs.max_depth; // the max depth
+  in >> label >> cs.max_depth;  // the max depth
   check_label(label, "max_depth:");
 
-  in >> label >> cs.mutations; // the number of mutations
+  in >> label >> cs.mutations;  // the number of mutations
   check_label(label, "mutations:");
 
-  in >> label >> cs.called_meth; // the number of sites called methylated
+  in >> label >> cs.called_meth;  // the number of sites called methylated
   check_label(label, "called_meth:");
 
-  in >> label >> cs.called_unmeth; // the number of sites called unmethylated
+  in >> label >> cs.called_unmeth;  // the number of sites called unmethylated
   check_label(label, "called_unmeth:");
 
-  in >> label >> cs.total_meth; // the mean aggregate
+  in >> label >> cs.total_meth;  // the mean aggregate
   check_label(label, "total_meth:");
 
   return in;

--- a/src/common/LevelsCounter.hpp
+++ b/src/common/LevelsCounter.hpp
@@ -90,10 +90,10 @@ struct LevelsCounter {
     return static_cast<double>(coverage()) / sites_covered;
   }
 
-  // sites_covered_fraction is the fraction of all sites that are covered at
-  // least once.
+  // sites_covered_frac is the fraction of all sites that are covered at least
+  // once.
   [[nodiscard]] double
-  sites_covered_fraction() const {
+  sites_covered_frac() const {
     return static_cast<double>(sites_covered) / total_sites;
   }
 

--- a/src/common/LevelsCounter.hpp
+++ b/src/common/LevelsCounter.hpp
@@ -76,6 +76,27 @@ struct LevelsCounter {
     return total_c + total_t;
   }
 
+  // mean_depth is the average number of reads contributing to methylation
+  // calls over all sites.
+  [[nodiscard]] double
+  mean_depth() const {
+    return static_cast<double>(coverage()) / total_sites;
+  }
+
+  // mean_depth_covered is the average number of reads contributing to
+  // methylation calls over all sites that are covered at least once.
+  [[nodiscard]] double
+  mean_depth_covered() const {
+    return static_cast<double>(coverage()) / sites_covered;
+  }
+
+  // sites_covered_fraction is the fraction of all sites that are covered at
+  // least once.
+  [[nodiscard]] double
+  sites_covered_fraction() const {
+    return static_cast<double>(sites_covered) / total_sites;
+  }
+
   // total_called is equal to called_meth plus called_unmeth
   [[nodiscard]] std::uint64_t
   total_called() const {

--- a/src/utils/format-reads.cpp
+++ b/src/utils/format-reads.cpp
@@ -52,7 +52,7 @@
 static std::int32_t
 merge_ends(bamxx::bam_rec &one, bamxx::bam_rec &two, bamxx::bam_rec &merged) {
   if (!are_mates(one, two))
-    return -std::numeric_limits<std::int32_t>::min();
+    return std::numeric_limits<std::int32_t>::min();
 
   // arithmetic easier using base 0 so subtracting 1 from pos
   const int one_s = get_pos(one);


### PR DESCRIPTION
This includes changes to the way summary stats are accumulated for uniq, bsrate and levels, with a change to one of the tags for levels output which might break some downstream processing that requires an exact tag